### PR TITLE
Improving napp unload

### DIFF
--- a/kyco/constants.py
+++ b/kyco/constants.py
@@ -5,3 +5,5 @@ instantiation"""
 # Min time (seconds) to send a new EchoRequest to a switch
 POOLING_TIME = 1
 CONNECTION_TIMEOUT = 15
+#: FLOOD_TIMEOUT in microseconds
+FLOOD_TIMEOUT = 100000

--- a/kyco/controller.py
+++ b/kyco/controller.py
@@ -460,6 +460,12 @@ class Controller(object):
         """
         napp = self.napps.pop(napp_name)
         napp.shutdown()
+        # Removing listeners from that napp
+        for event_type, listeners in napp._listeners.items():
+            for listener in listeners:
+                self.events_listeners[event_type].remove(listener)
+            if len(self.events_listeners[event_type]) == 0:
+                self.events_listeners.pop(event_type)
 
     def unload_napps(self):
         """Unload all loaded NApps that are not core NApps."""


### PR DESCRIPTION
Now the unload_napp method call the 'shutdown' method from the napp and
also remove the listeners from that method that are on the
events_listeners controller attribute.
