### PR TITLE
Dropping SC16 branch in favor of develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ __pycache__/
 
 *.swp
 
-
 # Distribution / packaging
 .Python
 env/
@@ -92,3 +91,7 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Auxilary files to test the controller
+aux_*.py
+aux_*.sh

--- a/kyco/constants.py
+++ b/kyco/constants.py
@@ -3,5 +3,7 @@
 This constantes may be overridden by values passed on the controller
 instantiation"""
 # Min time (seconds) to send a new EchoRequest to a switch
-POOLING_TIME = 1
+POOLING_TIME = 3
 CONNECTION_TIMEOUT = 15
+#: FLOOD_TIMEOUT in microseconds
+FLOOD_TIMEOUT = 100000

--- a/kyco/core/events.py
+++ b/kyco/core/events.py
@@ -196,5 +196,13 @@ class KycoMessageOutSetConfig(KycoMessageOut):
     pass
 
 
-class KycoMessageInPacketIn(KycoMessageIn):
+class KycoPacketIn(KycoMessageIn):
+    pass
+
+
+class KycoPacketOut(KycoMessageOut):
+    pass
+
+
+class KycoMessageOutFlowMod(KycoMessageOut):
     pass

--- a/kyco/core/events.py
+++ b/kyco/core/events.py
@@ -194,3 +194,7 @@ class KycoMessageInFeaturesReply(KycoMessageIn):
 
 class KycoMessageOutSetConfig(KycoMessageOut):
     pass
+
+
+class KycoMessageInPacketIn(KycoMessageIn):
+    pass

--- a/kyco/core/events.py
+++ b/kyco/core/events.py
@@ -206,3 +206,11 @@ class KycoPacketOut(KycoMessageOut):
 
 class KycoMessageOutFlowMod(KycoMessageOut):
     pass
+
+
+class KycoMessageOutStatsRequest(KycoMessageOut):
+    pass
+
+
+class KycoMessageInStatsReply(KycoMessageIn):
+    pass

--- a/kyco/core/switch.py
+++ b/kyco/core/switch.py
@@ -65,6 +65,16 @@ class KycoSwitch(object):
         self.sent_xid = None
         self.waiting_for_reply = False
         self.request_timestamp = 0
+        #: Dict associating mac addresses to switch ports.
+        #:      the key of this dict is a mac_address, and the value is a set
+        #:      containing the ports of this switch in which that mac can be
+        #:      found.
+        self.mac2port = {}
+        #: This flood_table will keep track of flood packets to avoid over
+        #:     flooding on the network. Its key is a hash composed by
+        #:     (eth_type, mac_src, mac_dst) and the value is the timestamp of
+        #:      the last flood.
+        self.flood_table = {}
 
     def disconnect(self):
         """Disconnect the switch.


### PR DESCRIPTION
Migrating all codes from sc16 branch to develop, so we keep working on the predefined workflow.

CHANGELOG: Added new attributes on the switch class, for l2_learning napps support.
CHANGELOG: Added new "MessageEvents" for Stats napp and l2_learning napps.
CHANGELOG: Added new constant.
CHANGELOG: Other minor fixes and improvements.
