### PR TITLE
Refactoring

### DIFF
--- a/kyco/controller.py
+++ b/kyco/controller.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Kyco - Kytos Contoller
 
 This module contains the main class of Kyco, which is
@@ -19,13 +18,12 @@ import os
 import re
 
 from importlib.machinery import SourceFileLoader
-from socket import error as SocketError
 from threading import Thread
 
 from kyco.core.buffers import KycoBuffers
 from kyco.core.events import KycoEvent
 from kyco.core.napps import KycoCoreNApp
-from kyco.core.switch import Connection, Switch
+from kyco.core.switch import Switch
 from kyco.core.tcp_server import KycoOpenFlowRequestHandler, KycoServer
 from kyco.utils import start_logger, now
 
@@ -159,7 +157,7 @@ class Controller(object):
 
     def uptime(self):
         # TODO: Return a better output
-        return self.started_at - now() if self.started_at else 0 
+        return self.started_at - now() if self.started_at else 0
 
     def notify_listeners(self, event):
         """Sends the event to the specified listeners.

--- a/kyco/core/events.py
+++ b/kyco/core/events.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module with Kyco Events"""
 
 from kyco.utils import now
@@ -9,7 +8,7 @@ from kyco.utils import now
 #######################
 
 class KycoEvent(object):
-    """Base Event class
+    """Base Event class.
 
     The event data will be passed on the content attribute, which should be a
     dictionary.
@@ -27,20 +26,14 @@ class KycoEvent(object):
 
     @property
     def destination(self):
-        try:
-            return self.content['destination']
-        except KeyError:
-            return None
+        return self.content.get('destination')
 
     def set_destination(self, destination):
         self.content['destination'] = destination
 
     @property
     def source(self):
-        try:
-            return self.content['source']
-        except KeyError:
-            return None
+        return self.content.get('source')
 
     def set_source(self, source):
         self.content['source'] = source

--- a/kyco/core/switch.py
+++ b/kyco/core/switch.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 *-*
 """Module with main classes related to Switches"""
 import logging
 from socket import error as SocketError
-from socket import socket as Socket
 
 from kyco.constants import CONNECTION_TIMEOUT, FLOOD_TIMEOUT
 from kyco.utils import now

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ Sphinx~=1.4.5
 # Linters, also for test
 pylama == 7.0.9 # There is a bug on 7.1.0
 pylama-pylint >= 2.2.1
+isort >= 4.2.5
 
 # Code coverage
 coverage >= 4.1


### PR DESCRIPTION
Notes:
- Removed unused imports
- Python 3 is unicode by default
- There's still many "python setup.py quick_lint" errors
