### PR TITLE
Fix signal kyco/core.shutdown

### DIFF
--- a/kyco/controller.py
+++ b/kyco/controller.py
@@ -139,7 +139,6 @@ class Controller(object):
 
         self.server.shutdown()
         self.buffers.send_stop_signal()
-        self.unload_napps()
 
         for thread in self._threads.values():
             log.info("Stopping thread: %s", thread.name)
@@ -150,6 +149,9 @@ class Controller(object):
                 pass
 
         self.started_at = None
+        self.unload_napps()
+        self.buffers = KycoBuffers()
+        self.server.server_close()
 
     def status(self):
         if self.started_at:
@@ -189,12 +191,12 @@ class Controller(object):
         log.info("Raw Event Handler started")
         while True:
             event = self.buffers.raw.get()
+            self.notify_listeners(event)
+            log.debug("Raw Event handler called")
 
             if event.name == "kyco/core.shutdown":
                 log.debug("RawEvent handler stopped")
                 break
-
-            self.notify_listeners(event)
 
     def msg_in_event_handler(self):
         """Handle msg_in events.
@@ -205,14 +207,13 @@ class Controller(object):
         log.info("Message In Event Handler started")
         while True:
             event = self.buffers.msg_in.get()
+            self.notify_listeners(event)
+            log.debug("MsgInEvent handler called")
 
             if event.name == "kyco/core.shutdown":
                 log.debug("MsgInEvent handler stopped")
                 break
 
-            log.debug("MsgInEvent handler called")
-            # Sending the event to the listeners
-            self.notify_listeners(event)
 
     def msg_out_event_handler(self):
         """Handle msg_out events.
@@ -228,12 +229,11 @@ class Controller(object):
                 log.debug("MsgOutEvent handler stopped")
                 break
 
-            log.debug("MsgOutEvent handler called")
             message = triggered_event.content['message']
-
             destination = triggered_event.destination
             destination.send(message.pack())
             self.notify_listeners(triggered_event)
+            log.debug("MsgOutEvent handler called")
 
     def app_event_handler(self):
         """Handle app events.
@@ -244,10 +244,8 @@ class Controller(object):
         log.info("App Event Handler started")
         while True:
             event = self.buffers.app.get()
-
-            log.debug("AppEvent handler called")
-            # Sending the event to the listeners
             self.notify_listeners(event)
+            log.debug("AppEvent handler called")
 
             if event.name == "kyco/core.shutdown":
                 log.debug("AppEvent handler stopped")

--- a/kyco/core/buffers.py
+++ b/kyco/core/buffers.py
@@ -3,8 +3,6 @@ import logging
 from queue import Queue
 
 from kyco.core.events import KycoEvent
-#from kyco.core.events import (KycoAppEvent, KycoMsgEvent, KycoRawEvent,
-#                              KycoShutdownEvent)
 
 __all__ = ['KycoBuffers']
 
@@ -21,12 +19,6 @@ class KycoEventBuffer(object):
 
     def put(self, event):
         if not self._reject_new_events:
-#            if not isinstance(event, self._event_base_class) and \
-#                    not isinstance(event, KycoShutdownEvent):
-#                # TODO: Raise a more proper exception
-#                msg = "{} event can not be added to {} buffer"
-#                raise Exception(msg.format(type(event).__name__, self.name))
-
             self._queue.put(event)
             log.debug('[buffer: %s] Added: %s', self.name, event.name)
 


### PR DESCRIPTION
- Fix signal shutdown in core.napps.py
- Add method _execute_loop to run execute method until the signal
  'kyco/core.shutdown' is received.
- Remove unused comments.
- Fix #101 
