### PR TITLE
Rename loggers #33

### DIFF
--- a/kyco/controller.py
+++ b/kyco/controller.py
@@ -31,7 +31,7 @@ from kyco.core.tcp_server import KycoOpenFlowRequestHandler, KycoServer
 from kyco.utils import now, start_logger
 from pyof.foundation.basic_types import HWAddress
 
-log = start_logger()
+log = start_logger(__name__)
 
 __all__ = ('Controller',)
 

--- a/kyco/core/buffers.py
+++ b/kyco/core/buffers.py
@@ -6,7 +6,7 @@ from kyco.core.events import KycoEvent
 
 __all__ = ['KycoBuffers']
 
-log = logging.getLogger('Kyco')
+log = logging.getLogger(__name__)
 
 
 class KycoEventBuffer(object):

--- a/kyco/core/napps.py
+++ b/kyco/core/napps.py
@@ -5,7 +5,7 @@ from threading import Event, Thread
 
 from kyco.utils import listen_to
 
-log = logging.getLogger('Kyco')
+log = logging.getLogger(__name__)
 
 __all__ = ('KycoCoreNApp', 'KycoNApp')
 

--- a/kyco/core/switch.py
+++ b/kyco/core/switch.py
@@ -9,7 +9,7 @@ from kyco.utils import now
 
 __all__ = ('Switch',)
 
-log = logging.getLogger('Kyco')
+log = logging.getLogger(__name__)
 
 
 class Interface(object):

--- a/kyco/core/tcp_server.py
+++ b/kyco/core/tcp_server.py
@@ -12,7 +12,7 @@ from kyco.core.switch import Connection
 
 __all__ = ['KycoServer', 'KycoOpenFlowRequestHandler']
 
-log = logging.getLogger('Kyco')
+log = logging.getLogger(__name__)
 
 
 class KycoServer(ThreadingMixIn, TCPServer):

--- a/kyco/utils.py
+++ b/kyco/utils.py
@@ -95,9 +95,9 @@ def run_on_thread(method):
     return threaded_method
 
 
-def start_logger():
+def start_logger(name):
     """Starts the loggers, both the Kyco and the KycoNApp"""
     fmt = '%(asctime)s - %(levelname)s [%(name)s] (%(threadName)s) %(message)s'
     # fmt += '\n           %(module)s - %(funcName)s - %(lineno)d'
     logging.basicConfig(format=fmt, level=logging.DEBUG)
-    return logging.getLogger('Kyco')
+    return logging.getLogger(name)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 Sphinx~=1.4.5
 
 # Linters, also for test
-pylama == 7.0.9 # There is a bug on 7.1.0
+pylama >= 7.2.3
 pylama-pylint >= 2.2.1
 isort >= 4.2.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ python-daemon
 python-openflow >= 1.1.0a2.post2
 kyco-core-napps >= 1.1.0a5.dev1
 flask
+
+# Used by stats app
+rrdtool >= 0.1.6


### PR DESCRIPTION
We should use `getLogger(__name__)`. This closes the last milestone issue.