### PR TITLE
Avoid multiple calls of NApp shutdown method

### DIFF
--- a/kyco/core/napps.py
+++ b/kyco/core/napps.py
@@ -86,8 +86,9 @@ class KycoNApp(Thread, metaclass=ABCMeta):
         Paramters
             event (:class:`KycoEvent`): event to be listened.
         """
-        self.__event.set()
-        self.shutdown()
+        if not self.__event.is_set():
+            self.__event.set()
+            self.shutdown()
 
     @abstractmethod
     def setup(self):


### PR DESCRIPTION
FIX #233