### PR TITLE
fixes napp folder permission by avoiding using mkdtemp.

### DIFF
--- a/kytos/core/napps/base.py
+++ b/kytos/core/napps/base.py
@@ -4,8 +4,8 @@ import os
 import re
 import sys
 import tarfile
-import tempfile
 from abc import ABCMeta, abstractmethod
+from random import randint
 from threading import Event, Thread
 
 from kytos.core.helpers import listen_to
@@ -122,7 +122,9 @@ class NApp:
         Return:
             pathlib.Path: Temp dir with package contents.
         """
-        tmp = tempfile.mkdtemp(prefix='kytos-napp-')
+        random_string = '{:0d}'.format(random.randint(0, 10**6))
+        tmp = '/tmp/kytos-napp-' + Path(filename).stem + '-' + random_string
+        os.mkdir(tmp)
         with tarfile.open(filename, 'r:xz') as tar:
             tar.extractall(tmp)
         return Path(tmp)

--- a/kytos/core/napps/manager.py
+++ b/kytos/core/napps/manager.py
@@ -1,7 +1,6 @@
 """Manage Network Application files."""
 import json
 import logging
-import os
 import shutil
 import urllib
 from pathlib import Path
@@ -90,7 +89,6 @@ class NAppsManager:
             dst = self._installed / napp.username / napp.name
             self._create_module(dst.parent)
             shutil.move(str(napp_folder), str(dst))
-            os.chmod(dst, mode=0o755)
         finally:
             if pkg_folder and pkg_folder.exists():
                 shutil.rmtree(str(pkg_folder))


### PR DESCRIPTION
 Also includes random number in tmp folder name.

cleaner solution to:
https://github.com/kytos/kytos/issues/349