### PR TITLE
Create folder for pidfile on setup

### DIFF
--- a/etc/kytos/kytos.conf.template
+++ b/etc/kytos/kytos.conf.template
@@ -9,7 +9,7 @@ workdir = {{ prefix }}/var/lib/kytos
 
 # PID file to write. When the controller starts, it will save the his pid on
 # this file.
-pidfile = {{ prefix }}/var/run/kytosd.pid
+pidfile = {{ prefix }}/var/run/kytos/kytosd.pid
 
 # This controller can be started in two modes: 'daemon' mode or 'interactive'
 # mode. On daemon mode, the process will detach from terminal when starts,

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -119,8 +119,7 @@ class Controller(object):
         """Create pidfile and call start_controller method."""
         self.enable_logs()
         pid = os.getpid()
-        # Create directory if it does not exist.
-        os.makedirs(os.path.dirname(self.options.pidfile), exist_ok=True)
+
         # Checks if a pidfile exists. Creates a new file.
         try:
             pidfile = open(self.options.pidfile, mode='x')
@@ -135,12 +134,17 @@ class Controller(object):
                 # If kill() doesn't return an error, older instance is still
                 # running.
                 # Otherwise, overwrite the file and proceed.
-                self.log.info("Failed to create a pidfile. "
+                self.log.info("Failed to create a pidfile: "
                               "Is kytos already running?")
                 self.log.info("Aborting")
                 exit(os.EX_CANTCREAT)
             except OSError:
-                pidfile = open(self.options.pidfile, mode='w')
+                try:
+                    pidfile = open(self.options.pidfile, mode='w')
+                except OSError:
+                    self.log.info("Failed to create a pidfile: "
+                                  "Permission denied.")
+                    exit(os.EX_NOPERM)
 
         # Identifies the process that created the pidfile.
         pidfile.write(str(pid))

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,12 @@ class CommonInstall:
                     dst_file.write(content)
 
     @staticmethod
+    def create_pid_folder():
+        """Create the folder in /var/run to hold the pidfile."""
+        pid_folder = os.path.join(BASE_ENV, 'var/run/kytos')
+        os.makedirs(pid_folder, mode=0o777, exist_ok=True)
+
+    @staticmethod
     def create_paths():
         """Method used to create the paths used by Kytos in develop mode."""
         directories = [os.path.join(BASE_ENV, 'etc/kytos')]
@@ -148,6 +154,7 @@ class InstallMode(install, CommonInstall):
             self.do_egg_install()
         self.generate_file_from_template(TEMPLATE_FILES, BASE_ENV,
                                          prefix=BASE_ENV)
+        self.create_pid_folder()
 
 
 class DevelopMode(develop, CommonInstall):
@@ -168,6 +175,7 @@ class DevelopMode(develop, CommonInstall):
 
         for file_name in TEMPLATE_FILES:
             self.generate_file_link(file_name.replace('.template', ''))
+        self.create_pid_folder()
 
     @staticmethod
     def generate_file_link(file_name):


### PR DESCRIPTION
Fix #368.

Warning: To solve this problem, a folder is being created with 777 permission inside /var/run. If this is not desired somehow, please request changes.