### PR TITLE
Create folder for pidfile in /var/run when running

### DIFF
--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -118,6 +118,9 @@ class Controller(object):
         self.enable_logs()
         pid = os.getpid()
 
+        # Creates directory if it doesn't exist
+        os.makedirs(os.path.dirname(self.options.pidfile), exist_ok=True)
+
         # Checks if a pidfile exists. Creates a new file.
         try:
             pidfile = open(self.options.pidfile, mode='x')


### PR DESCRIPTION
This is a workaround for #381. It does not allow kytos to be run as a regular user, so the issue shall stay open.
This fixes the problem of running as root after a restart.
The permanent solution to #381 needs further discussion.