### PR TITLE
fixes switch.is_connected method to check if connection exists first.

### DIFF
--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -377,7 +377,8 @@ class Switch(object):
 
     def is_connected(self):
         """Verify if the switch is connected to a socket."""
-        return self.connection.is_connected() and self.is_active()
+        return (self.connection is not None and
+                self.connection.is_connected() and self.is_active())
 
     def update_connection(self, connection):
         """Update switch connection.


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/site-packages/kytos-2017.1b1-py3.6.egg/kytos/core/napps/base.py", line 218, in run
    self.execute()
  File "//var/lib/kytos/napps/kytos/of_core/main.py", line 38, in execute
    if switch.is_connected():
  File "/usr/lib/python3.6/site-packages/kytos-2017.1b1-py3.6.egg/kytos/core/switch.py", line 380, in is_connected
    return self.connection.is_connected() and self.is_active()
AttributeError: 'NoneType' object has no attribute 'is_connected'
