### PR TITLE
Catching SystemExit before start the kytos' shell

### DIFF
--- a/bin/kytosd
+++ b/bin/kytosd
@@ -3,6 +3,7 @@
 import daemon
 import IPython
 import signal
+import sys
 
 from IPython.terminal.embed import InteractiveShellEmbed
 from IPython.terminal.prompts import Prompts, Token
@@ -55,7 +56,14 @@ if __name__ == '__main__':
     config = KytosConfig()
     controller = Controller(config.options['daemon'])
     if controller.options.foreground:
-        controller.start()
+
+        try:
+            controller.start()
+        except SystemExit as e:
+            controller.log.error(e)
+            controller.log.info("Kytos start aborted.")
+            sys.exit()
+
         address = controller.server.server_address[0]
         port = controller.server.server_address[1]
         banner1 += " tcp://{}:{}\n".format(address, port)
@@ -73,5 +81,9 @@ if __name__ == '__main__':
         controller.stop()
     else:
         with daemon.DaemonContext():
-            controller.start()
-        print('Kytos daemon started.')
+            try:
+                controller.start()
+            except SystemExit as e:
+                controller.log.error(e)
+                controller.log.info("Kytos daemon start aborted.")
+                sys.exit()

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -151,16 +151,15 @@ class Controller(object):
                 # If kill() doesn't return an error, there's a process running
                 # with the same PID. We assume it is Kytos and quit.
                 # Otherwise, overwrite the file and proceed.
-                self.log.error("PID file %s exists. Delete it if Kytos is not"
-                               "running. Aborting.")
-                sys.exit(os.EX_CANTCREAT)
+                error_msg = ("PID file {} exists. Delete it if Kytos is not "
+                             "running. Aborting.")
+                sys.exit(error_msg.format(self.options.pidfile))
             except OSError:
                 try:
                     pidfile = open(self.options.pidfile, mode='w')
                 except OSError as e:
-                    self.log.error("Failed to create pidfile %s: %s",
-                                   self.options.pidfile, e)
-                    sys.exit(os.EX_NOPERM)
+                    error_msg = "Failed to create pidfile {}: {}."
+                    sys.exit(error_msg.format(self.options.pidfile, e))
 
         # Identifies the process that created the pidfile.
         pidfile.write(str(pid))
@@ -207,10 +206,8 @@ class Controller(object):
             try:
                 thread.start()
             except OSError as e:
-                self.log.error("Error starting thread %s", thread)
-                self.log.error(e)
-                self.log.error("Kytos start aborted.")
-                sys.exit()
+                error_msg = "Error starting thread {}: {}."
+                sys.exit(error_msg.format(thread, e))
 
         self.log.info("Loading Kytos NApps...")
         self.load_napps()


### PR DESCRIPTION
Avoid start Kytos' Shell when thrown exception while starting the controller.

Fix #408 