### PR TITLE
Fix web interface memory leak

### DIFF
--- a/kytos/web-ui/static/js/kytos-logs.js
+++ b/kytos/web-ui/static/js/kytos-logs.js
@@ -4,6 +4,8 @@
   var connected=false;
   var current_line = 0;
   var socket = io.connect('/logs');
+  // prevent browser from crashing with too many lines
+  var max_lines = 50;
 
   socket.on('connect', function(){
     turn_on_led()
@@ -61,8 +63,8 @@
   }
 
   function add_log_message(msg, src_tag) {
-    if ($('#tab_logs div.log_message').length >= 500) {
-      $('#tab_logs').find('#tab_logs:first').remove();
+    if ($('#tab_logs .log_message').length >= max_lines) {
+      $('#tab_logs').find('.log_message:first').remove();
     }
     $('<div/>', {
         text: msg,
@@ -73,7 +75,8 @@
 
   function request_log_changes(){
     if (connected && $('#enable_log')[0].checked) {
-      socket.emit('show logs', {"current_line": current_line})
+      socket.emit('show logs', {"current_line": current_line,
+                                "max_lines": max_lines})
     }
   }
   setInterval(request_log_changes, 3000);

--- a/tests/test_core/test_websocket.py
+++ b/tests/test_core/test_websocket.py
@@ -1,0 +1,56 @@
+"""Test websocket log."""
+from unittest import TestCase, mock
+
+from kytos.core.websocket import LogWebSocket
+
+
+class TestLogWebSocket(TestCase):
+    """Test sending logs to the web interface."""
+
+    #: int: max number of lines to return (requested by the web client)
+    MAX_LINES = 3
+
+    @classmethod
+    @mock.patch('kytos.core.websocket.emit')
+    def _get_new_lines(cls, current_line, emit=None):
+        """Our answer to the web client.
+
+        Args:
+            current_line (str): Index of the first line to be sent.
+
+        Returns:
+            list: Log lines.
+        """
+        total_lines = 10
+        log = LogWebSocket()
+
+        # Simulate kytosd writing to log
+        for i in range(total_lines):
+            log.stream.write(f'{i}\n')
+
+        # Simulate the request from the web client
+        client_json = dict(current_line=current_line, max_lines=cls.MAX_LINES)
+        log.handle_messages(client_json)
+
+        return emit.call_args[0][1]
+
+    def test_max_lines(self):
+        """Should return no more lines than max_lines."""
+        answer2client = self._get_new_lines(0)
+        lines = answer2client['buff']
+        self.assertEqual(self.MAX_LINES, len(lines))
+
+    def test_continuation_content(self):
+        """Should send the next line in the next request.
+
+        Assume there are no more new messages than max_lines.
+        """
+        answer2client = self._get_new_lines(3)
+        lines = answer2client['buff']
+        self.assertListEqual(['7', '8', '9'], lines)
+
+    def test_continuation_index(self):
+        """Should return the index of the next log line to be retrieved."""
+        answer2client = self._get_new_lines(3)
+        next_line = answer2client['last_line']
+        self.assertEqual(10, next_line)


### PR DESCRIPTION
- Limit the number of lines in log panel to 50
- Reduce backend buffer for logs to 100 lines
- Add LogWebSocket unit tests