### PR TITLE
Add endpoint to display controller.options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ All notable changes to the kytos project will be documented in this file.
 ********************************
 Added
 =====
+- '/kytos/configuration/' endpoint to display kytos configuration.
 
 Changed
 =======

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -83,30 +83,29 @@ class APIServer:
         """Return string with routes registered by Api Server."""
         return [x.rule for x in self.app.url_map.iter_rules()]
 
-    def register_kytos_routes(self):
+    def register_api_server_routes(self):
         """Register initial routes from kytos using ApiServer.
 
-        Initial routes are: ['/kytos/status', '/kytos/shutdown']
+        Initial routes are: ['/kytos/status/', '/kytos/shutdown/']
         """
         if '/kytos/status/' not in self.rest_endpoints:
-            self.app.add_url_rule('/kytos/status/', self.status_api.__name__,
-                                  self.status_api, methods=['GET'])
+            self.register_rest_endpoint('/status/',
+                                        self.status_api, methods=['GET'])
 
         if '/kytos/shutdown' not in self.rest_endpoints:
-            self.app.add_url_rule('/kytos/shutdown',
-                                  self.shutdown_api.__name__,
-                                  self.shutdown_api, methods=['GET'])
+            self.register_rest_endpoint('/shutdown/',
+                                        self.shutdown_api, methods=['GET'])
 
     @staticmethod
     def status_api():
-        """Display json with kytos status using the route '/kytos/status'."""
+        """Display json with kytos status using the route '/kytos/status/'."""
         return '{"response": "running"}', 201
 
     @staticmethod
     def stop_api_server():
         """Method used to send a shutdown request to stop Api Server."""
         try:
-            urlopen('http://127.0.0.1:8181/kytos/shutdown')
+            urlopen('http://127.0.0.1:8181/kytos/shutdown/')
         except URLError:
             pass
 

--- a/tests/test_core/test_api_server.py
+++ b/tests/test_core/test_api_server.py
@@ -1,0 +1,64 @@
+"""APIServer tests."""
+
+import logging
+import unittest
+
+from kytos.core.api_server import APIServer
+
+
+class TestAPIServer(unittest.TestCase):
+    """Test the class APIServer."""
+
+    def setUp(self):
+        """Instantiate a APIServer."""
+        self.api_server = APIServer('CustomName', False)
+
+    def test_register_rest_endpoint(self):
+        """Test whether register_rest_endpoint is registering an endpoint."""
+        self.api_server.register_rest_endpoint('/custom_method/',
+                                               self.__custom_endpoint,
+                                               methods=['GET'])
+
+        expected_endpoint = '/kytos/custom_method/'
+        actual_endpoints = self.api_server.rest_endpoints
+        self.assertIn(expected_endpoint, actual_endpoints)
+
+    def test_register_api_server_routes(self):
+        """Server routes should include status and shutdown endpoints."""
+        self.api_server.register_api_server_routes()
+
+        expecteds = ['/kytos/status/', '/kytos/shutdown/',
+                     '/static/<path:filename>']
+
+        actual_endpoints = self.api_server.rest_endpoints
+
+        self.assertListEqual(sorted(expecteds), sorted(actual_endpoints))
+
+    def test_rest_endpoints(self):
+        """Test whether rest_endpoint returns all registered endpoints."""
+        endpoints = ['/custom/', '/custom_2/', '/custom_3/']
+
+        for endpoint in endpoints:
+            self.api_server.register_rest_endpoint(endpoint,
+                                                   self.__custom_endpoint,
+                                                   methods=['GET'])
+
+        expected_endpoints = ['/kytos{}'.format(e) for e in endpoints]
+        expected_endpoints.append('/static/<path:filename>')
+
+        actual_endpoints = self.api_server.rest_endpoints
+        self.assertListEqual(sorted(expected_endpoints),
+                             sorted(actual_endpoints))
+
+    def test_set_debug(self):
+        """Test whether set_debug is setting debug level."""
+        self.api_server.set_debug(True)
+        self.assertEqual(self.api_server.log.level, logging.DEBUG)
+
+        self.api_server.set_debug(False)
+        self.assertEqual(self.api_server.log.level, logging.WARNING)
+
+    @staticmethod
+    def __custom_endpoint():
+        """Custom method used by APIServer."""
+        return "Custom Endpoint"

--- a/tests/test_core/test_controller.py
+++ b/tests/test_core/test_controller.py
@@ -1,0 +1,57 @@
+"""Controller tests."""
+
+import json
+import unittest
+
+from kytos.core.controller import Controller
+
+
+class TestController(unittest.TestCase):
+    """Test the class Controller."""
+
+    def setUp(self):
+        """Instantiate a controller with custom options."""
+        class CustomOption:
+            """Class to represent a custom option used by Kytos."""
+
+            def __init__(self, **kwargs):
+                """Construtor method of CustomOption."""
+                self.__dict__.update(kwargs)
+
+        options_dict = {'api_port': '8181',
+                        'conf': '/etc/kytos/kytos.conf',
+                        'daemon': 'False',
+                        'debug': 'False',
+                        'foreground': True,
+                        'installed_napps': '/var/lib/kytos/napps/.installed',
+                        'listen': '0.0.0.0',
+                        'logging': '/etc/kytos/logging.ini',
+                        'napps': '/var/lib/kytos/napps',
+                        'napps_repositories': ['https://www.sample.com/repo/'],
+                        'pidfile': '/var/run/kytos/kytosd.pid',
+                        'port': '6633',
+                        'workdir': '/var/lib/kytos'}
+
+        self.options = options_dict
+        self.controller = Controller(CustomOption(**options_dict))
+
+    def test_configuration_endpoint(self):
+        """Should return the attribute options as json."""
+        expected = json.dumps(self.options)
+        actual = self.controller.configuration_endpoint()
+        self.assertEqual(expected, actual)
+
+    def test_register_configuration_endpoint(self):
+        """Should register the endpoint '/kytos/config/'."""
+        expected_endpoint = '/kytos/config/'
+        actual_endpoints = self.controller.api_server.rest_endpoints
+        self.assertIn(expected_endpoint, actual_endpoints)
+
+    def test_register_kytos_endpoints(self):
+        """Verify all endpoints registered by Controller."""
+        expected_endpoints = ['/kytos/config/', '/kytos/shutdown/',
+                              '/kytos/status/', '/index.html', '/',
+                              '/static/<path:filename>']
+        actual_endpoints = self.controller.api_server.rest_endpoints
+        self.assertListEqual(sorted(expected_endpoints),
+                             sorted(actual_endpoints))


### PR DESCRIPTION
Change the class controller to register all endpoints before start the APIServer.
Add the endpoint '/kytos/configuration' to render the options loaded by kytos.
Add some test for kytos/core/{controller, api_server}.py
Fix kytos/kytos-utils#86