### PR TITLE
Fix register_rest_endpoint method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to the kytos project will be documented in this file.
 Added
 =====
 - '/kytos/configuration/' endpoint to display kytos configuration.
-- Add 'api_port' in kytos.conf, with default value equals 8181.
+- Add 'api_port' in kytos.conf. The default value is 8181.
 
 Changed
 =======
@@ -23,7 +23,8 @@ Fixed
 =====
 - Web interface:
   - Fixed memory and CPU usage
-- Fix starting debug mode using the command kytos -D
+- Now Kytos can register endpoints with different methods for the same URL.
+- Now it's possible to start in debug mode using the command kytosd -D
 
 Security
 ========

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -60,9 +60,20 @@ class APIServer:
                                  e.g: ['GET', 'PUT', 'POST', 'DELETE', 'PATCH']
         """
         new_endpoint_url = "/kytos{}".format(url)
-        if new_endpoint_url not in self.rest_endpoints:
-            self.app.add_url_rule(new_endpoint_url, function.__name__,
-                                  function, methods=methods)
+
+        for endpoint in self.app.url_map.iter_rules():
+            if endpoint.rule == new_endpoint_url:
+                for method in methods:
+                    if method in endpoint.methods:
+                        message = ("Method '{}' already registered for " +
+                                   "URL '{}'").format(method, new_endpoint_url)
+                        self.log.warning(message)
+                        self.log.warning("WARNING: Overlapping endpoint was " +
+                                         "NOT registered.")
+                        return
+
+        self.app.add_url_rule(new_endpoint_url, function.__name__, function,
+                              methods=methods)
 
     def register_web_ui(self):
         """Method used to register routes to the admin-ui homepage."""


### PR DESCRIPTION
Fix #448
Check URL and method before denying a new rest endpoint.
Log a warning message if an endpoint is not registered.