### PR TITLE
Update sphinx and sphinx_bootstrap_theme

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 libsass
 
 # For running doctests (during "python setup.py test")
-Sphinx >= 1.4.5
-sphinx_bootstrap_theme
+Sphinx == 1.5.6
+sphinx_bootstrap_theme == 0.4.14
 
 # Linters, also in test target
 # Pylama still not compatible with pydocstyle version 2.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,9 +2,9 @@
 # are required:
 
 # Sphinx is required for running doctests (and building documentation)
-Sphinx >= 1.4.5
+Sphinx == 1.5.6
 # To run "make livehtml", build docs and refresh browser automatically when
 # files change
 sphinx-autobuild >= 0.6.0
 sphinx-rtd-theme >= 0.1.9
-sphinx_bootstrap_theme
+sphinx_bootstrap_theme == 0.4.14


### PR DESCRIPTION
This update is necessary to run make docs correctly, without that the template
will break or the bootstrap theme will appear red.