### PR TITLE
Remove command in NApps for self shutdown

### DIFF
--- a/kytos/core/napps/base.py
+++ b/kytos/core/napps/base.py
@@ -228,7 +228,6 @@ class KytosNApp(Thread, metaclass=ABCMeta):
         """
         if not self.__event.is_set():
             self.__event.set()
-            self.shutdown()
 
     @abstractmethod
     def setup(self):


### PR DESCRIPTION
NApps don't need to shutdown themselves - the controller calls their shutdown method in it's own shutdown process.
Fix #500