### PR TITLE
Fix Scrutinizer CI tests

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,3 +14,6 @@ build:
     dependencies:
         override:
             - true
+    tests:
+        before:
+            - sed -i 's|.*http.*watchdog.*||' requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,5 @@ commands=
 deps=
     git+git://github.com/kytos/python-openflow.git
     git+git://github.com/kytos/kytos-utils.git
+    git+git://github.com/diraol/watchdog.git#egg=watchdog
     -rrequirements-dev.txt


### PR DESCRIPTION
Scrutinizer CI doesn't allow downloading through HTTP(S).
This patch modifies only the tests by installing the watchdog package through
git protocol instead of HTTP.