### PR TITLE
fixed how to contribute link on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ Contributing
 ************
 
 If you want to contribute to this project, please read `Kytos Documentation
-<https://docs.kytos.io/kytos/contributing/>`__ website.
+<https://docs.kytos.io/kytos/developer/how_to_contribute/>`__ website.
 
 License
 *******


### PR DESCRIPTION
Guys, this link <https://docs.kytos.io/kytos/contributing/ that is mentioned in the README was broken. Apparently, it was supposed to be this one instead: https://docs.kytos.io/kytos/developer/how_to_contribute/. 

