### PR TITLE
Add contributing and ISSUE/PR GH Templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+<Please, fill in this template so we can have the necessary information to
+understand your issue.>
+## This is a:
+ - [ ] Bug Report
+ - [ ] Feature Request
+ - [ ] Improvement Proposal
+
+## Expected Behavior
+<describe here the expected behavior>
+
+## Actual Behavior
+<describe here the actual behavior>
+
+## Steps to Reproduce the Problem
+<put here the necessary steps to reproduce the problem or the behavior>
+
+  1.
+  2.
+  3.
+
+## Environment
+
+Run the following commands so we can understand your environment correctly:
+
+  - Platform: 
+    - <lsb_release -a>
+    - <uname -a>
+  - Python-path: <which python>
+  - Python: <python --version>
+  - pip-path: <which pip>
+  - pip: <pip --version>
+  - kytosd: <kytosd --version>
+  - kytos: <kytos --version>
+  - NApps: <kytos napps list>
+  - python-packages: <pip freeze>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+* **Please check if the PR fulfills these requirements**
+- [ ] The commit message follows our guidelines
+- [ ] **Tests** for the changes have been added (for bug fixes / features)
+- [ ] **Docs** have been added / updated (for bug fixes / features)
+- [ ] **Changelog** was updated
+
+* **Is this PR related to any issue?**
+If this issue is related to a PR, reference the issue on the commit message or
+on the PR description. Also, if this PR closes/fixes the issue, also add
+`Fix #<issueNumber>` to close the issue automatically when the PR is accepted.
+Also, if the PR already answer the three questions bellow you do not need to
+rewrite them over here. If needed, comment/update the issue according to this
+PR.
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+* **What is the current behavior?** (You can also link to an open issue here)
+
+
+* **What is the new behavior (if this is a feature change)?**
+
+
+* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+
+
+* **Other information**:

--- a/.github/contributing.rst
+++ b/.github/contributing.rst
@@ -1,0 +1,1 @@
+../docs/developer/how_to_contribute.rst

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Security
 Added
 =====
 - `@rest` decorator can also be used before `@classmethod` or `@staticmethod`
+- GH Contributing guidelines
+- Issue/PR GH templates
 
 Changed
 =======


### PR DESCRIPTION
Add templates with guidelines about what information that should be
added to new issues and also to PullRequests. Also contains the
`contributing` guidelines.

Fix #595