### PR TITLE
Change 'new switch' event name

### DIFF
--- a/docs/developer/listened_events.rst
+++ b/docs/developer/listened_events.rst
@@ -31,7 +31,7 @@ with all classes and NApps who can listen to these Events.
 |                                   +-------------------------------------------------+-------------------------------------------------------------------+
 |                                   | :class:`~kytos.core.napps.base.KytosNApp`       | - :func:`~kytos.core.napps.KytosNApp._shutdown_handler`           |
 +-----------------------------------+-------------------------------------------------+-------------------------------------------------------------------+
-| kytos/core.switches.new           | NApp: kytos/of_ipv6drop                         | - :func:`kytos/of_ipv6drop.ipv6_drop`                             |
+| kytos/core.switch.new             | NApp: kytos/of_ipv6drop                         | - :func:`kytos/of_ipv6drop.ipv6_drop`                             |
 +-----------------------------------+-------------------------------------------------+-------------------------------------------------------------------+
 | kytos/core.messages.openflow.new  | Napp: kytos/of_core                             | - :func:`kytos/of_core.handle_core_new_connection`                |
 +-----------------------------------+-------------------------------------------------+-------------------------------------------------------------------+

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -467,7 +467,7 @@ class Controller(object):
             switch = Switch(dpid=dpid)
             self.add_new_switch(switch)
 
-            event = KytosEvent(name='kytos/core.switches.new',
+            event = KytosEvent(name='kytos/core.switch.new',
                                content={'switch': switch})
 
         old_connection = switch.connection


### PR DESCRIPTION
Rename 'core.switches.new' to 'core.switch.new'
Fix #614