### PR TITLE
Fixed typos in some docstrings.

### DIFF
--- a/bin/kytosd
+++ b/bin/kytosd
@@ -35,7 +35,7 @@ banner1 = """\033[95m
 Welcome to Kytos SDN Platform!
 
 We are doing a huge effort to make sure that this console will work fine. But
-for now is still experimental.
+for now it's still experimental.
 
 Kytos website.: https://kytos.io/
 Documentation.: https://docs.kytos.io/

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -25,7 +25,7 @@ def listen_to(event, *events):
 
     The event that will be listened to is always a string, but it can represent
     a regular expression to match against multiple Event Types. All listened
-    events is documented in :doc:`developer/listened_events` section.
+    events are documented in :doc:`developer/listened_events` section.
 
     Example of usage:
 
@@ -61,7 +61,7 @@ def listen_to(event, *events):
         """Decorate the handler method.
 
         Returns:
-            A method with a `events` attribute (list of events to be listened)
+            A method with an `events` attribute (list of events to be listened)
             and also decorated to run on a new thread.
 
         """

--- a/kytos/core/tcp_server.py
+++ b/kytos/core/tcp_server.py
@@ -73,7 +73,7 @@ class KytosRequestHandler(BaseRequestHandler):
     }
 
     def __init__(self, request, client_address, server):
-        """Contructor takes the parameters below.
+        """Initialize a request handler object for each connection.
 
         Args:
             request (socket.socket):

--- a/kytos/core/websocket.py
+++ b/kytos/core/websocket.py
@@ -24,7 +24,7 @@ class WebSocketHandler:
     def _filter_web_requests(record):
         """Only allow web server messages with level higher than info.
 
-        Do not print web requests (INFO level) to avoid infinit loop when
+        Do not print web requests (INFO level) to avoid infinite loop when
         printing the logs in the web interface with long-polling mode.
         """
         return record.name != 'werkzeug' or record.levelno > logging.INFO


### PR DESCRIPTION
Just some small fixes to typos in docstrings and in the main Kytos interactive prompt.