### PR TITLE
Remove unused constant (fix #80)

### DIFF
--- a/kytos/core/constants.py
+++ b/kytos/core/constants.py
@@ -1,10 +1,8 @@
 """Module with the main constants from Kytos.
 
-This constantes may be overridden by values passed on the controller
+These constants may be overridden by values passed on the controller
 instantiation.
 """
-# Min time (seconds) to send a new EchoRequest to a switch
-POOLING_TIME = 3
 CONNECTION_TIMEOUT = 70
-#: FLOOD_TIMEOUT in microseconds
+# FLOOD_TIMEOUT in microseconds
 FLOOD_TIMEOUT = 100000


### PR DESCRIPTION
POOLING_TIME is declared but not used in Kytos or NApps.