### PR TITLE
asyncio - new tcp server and controller

### DIFF
--- a/bin/kytosd
+++ b/bin/kytosd
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3.6
+"""Start Kytos SDN Platform core."""
+
+import asyncio
+
 from kytos.core import kytosd
 
-if __name__ == "__main__":
-    kytosd.main()
+
+def main():
+    loop = asyncio.get_event_loop()
+    loop.call_soon(kytosd.async_main)
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/kytos/core/atcp_server.py
+++ b/kytos/core/atcp_server.py
@@ -1,0 +1,185 @@
+"""AsyncIO TCP Server for Kytos."""
+
+import asyncio
+import logging
+
+from kytos.core.connection import Connection
+from kytos.core.events import KytosEvent
+
+LOG = logging.getLogger("atcp_server")
+
+
+def exception_handler(loop, context):
+    """Exception handler to avoid tracebacks because of network timeouts."""
+    if isinstance(context['exception'], TimeoutError):
+        LOG.info('Lost connection on socket %r', context['transport'])
+    else:
+        loop.default_exception_handler(context)
+
+
+class KytosServer:
+    """Abstraction of a TCP Server to listen to packages from the network.
+
+    The KytosServer will listen on the specified port
+    for any new TCP request from the network and then instantiate the
+    specified RequestHandler to handle the new request.
+    It creates a new thread for each Handler.
+    """
+
+    def __init__(self, server_address, server_protocol, controller,
+                 protocol_name):
+        """Create the object without starting the server.
+
+        Args:
+            server_address (tuple): Address where the server is listening.
+                example: ('127.0.0.1', 80)
+            server_protocol(asyncio.Protocol):
+                Class that will be instantiated to handle each request.
+            controller (:class:`~kytos.core.controller.Controller`):
+                An instance of Kytos Controller class.
+            protocol_name (str): Southbound protocol name that will be used
+        """
+        self.server_address = server_address
+        self.server_protocol = server_protocol
+        self.controller = controller
+        self.protocol_name = protocol_name
+
+        # This will be an `asyncio.Server` instance after `serve_forever` is
+        # called
+        self._server = None
+
+        # Here we compose the received `server_protocol` class with a `server`
+        # object pointing to this instance
+        self.server_protocol.server = self
+
+        self.loop = asyncio.get_event_loop()
+        self.loop.set_exception_handler(exception_handler)
+
+    def serve_forever(self):
+        """Handle requests until an explicit shutdown() is called."""
+        addr, port = self.server_address[0], self.server_address[1]
+
+        self._server = self.loop.create_server(self.server_protocol,
+                                               addr, port)
+
+        try:
+            task = self.loop.create_task(self._server)
+            LOG.info("Kytos listening at %s:%s", addr, port)
+        except Exception:
+            LOG.error('Failed to start Kytos TCP Server at %s:%s', addr, port)
+            task.close()
+            raise
+
+    def shutdown(self):
+        """Call .close() on underlying TCP server, closing client sockets."""
+        self._server.close()
+        # self.loop.run_until_complete(self._server.wait_closed())
+
+
+class KytosServerProtocol(asyncio.Protocol):
+    """Kytos' main request handler.
+
+    It is instantiated once per connection between each switch and the
+    controller.
+    The setup method will dispatch a KytosEvent (``kytos/core.connection.new``)
+    on the controller, that will be processed by a Core App.
+    The finish method will close the connection and dispatch a KytosEvent
+    (``kytos/core.connection.closed``) on the controller.
+    """
+
+    known_ports = {
+        6633: 'openflow',
+        6653: 'openflow'
+    }
+
+    def __init__(self):
+        """Initialize protocol and check if server attribute was set."""
+        self._loop = asyncio.get_event_loop()
+
+        self.connection = None
+        self.transport = None
+        self._rest = b''
+
+        # server attribute is set outside this class, in KytosServer.init()
+        # Here we initialize it to None to avoid pylint warnings
+        if not getattr(self, 'server'):
+            self.server = None
+
+        # Then we check if it was really set
+        if not self.server:
+            raise ValueError("server instance must be assigned before init")
+
+    def connection_made(self, transport):
+        """Handle new client connection, passing it to the controller.
+
+        Build a new Kytos `Connection` and send a ``kytos/core.connection.new``
+        KytosEvent through the app buffer.
+        """
+        self.transport = transport
+
+        addr, port = transport.get_extra_info('peername')
+        _, server_port = transport.get_extra_info('sockname')
+        socket = transport.get_extra_info('socket')
+
+        LOG.info("New connection from %s:%s", addr, port)
+
+        self.connection = Connection(addr, port, socket)
+
+        # ASYNC TODO:
+        # if self.server.protocol_name:
+        #     self.known_ports[server_port] = self.server.protocol_name
+
+        if server_port in self.known_ports:
+            protocol_name = self.known_ports[server_port]
+        else:
+            protocol_name = f'{server_port:04d}'
+        self.connection.protocol.name = protocol_name
+
+        # ASYNC TODO:
+        # self.request.settimeout(70)
+
+        event_name = 'kytos/core.connection.new'
+        # f'kytos/core.{self.connection.protocol.name}.connection.new'
+        event = KytosEvent(name=event_name,
+                           content={'source': self.connection})
+
+        self._loop.create_task(self.server.controller.buffers.raw.aput(event))
+
+    def data_received(self, data):
+        """Handle each request and place its data in the raw event buffer.
+
+        Sends the received binary data in a ``kytos/core.{protocol}.raw.in``
+        event on the raw buffer.
+        """
+        data = self._rest + data
+
+        LOG.debug("New data from %s:%s (%s bytes)",
+                  self.connection.address, self.connection.port, len(data))
+
+        # LOG.debug("New data from %s:%s (%s bytes): %s", self.addr, self.port,
+        #           len(data), binascii.hexlify(data))
+
+        content = {'source': self.connection, 'new_data': data}
+        event_name = f'kytos/core.{self.connection.protocol.name}.raw.in'
+        event = KytosEvent(name=event_name, content=content)
+
+        self._loop.create_task(self.server.controller.buffers.raw.aput(event))
+
+    def connection_lost(self, exc):
+        """Close the connection socket and generate connection lost event.
+
+        Emits a ``kytos/core.connection.lost`` event through the App buffer.
+        """
+        LOG.info("Connection lost with client %s:%s. Reason: %s",
+                 self.connection.address, self.connection.port, exc)
+
+        self.connection.close()
+
+        content = {'source': self.connection}
+        if exc:
+            content['exception'] = exc
+        event_name = \
+            f'kytos/core.{self.connection.protocol.name}.connection.lost'
+        event = KytosEvent(name=event_name, content=content)
+
+        self._loop.create_task(self.server.controller.buffers.app.aput(event))

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -1,6 +1,8 @@
 """Kytos Buffer Classes, based on Python Queue."""
 import logging
-from queue import Queue
+
+# from queue import Queue
+from janus import Queue
 
 from kytos.core.events import KytosEvent
 
@@ -25,7 +27,7 @@ class KytosEventBuffer(object):
         self._reject_new_events = False
 
     def put(self, event):
-        """Insert a event in KytosEventBuffer if reject new events is False.
+        """Insert an event in KytosEventBuffer if reject_new_events is False.
 
         Reject new events is True when a kytos/core.shutdown message was
         received.
@@ -35,8 +37,32 @@ class KytosEventBuffer(object):
                 KytosEvent sent to queue.
         """
         if not self._reject_new_events:
-            self._queue.put(event)
+            self._queue.sync_q.put(event)
             LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
+
+        if event.name == "kytos/core.shutdown":
+            LOG.info('[buffer: %s] Stop mode enabled. Rejecting new events.',
+                     self.name)
+            self._reject_new_events = True
+
+    async def aput(self, event):
+        """Insert a event in KytosEventBuffer if reject new events is False.
+
+        Reject new events is True when a kytos/core.shutdown message was
+        received.
+
+        Args:
+            event (:class:`~kytos.core.events.KytosEvent`):
+                KytosEvent sent to queue.
+        """
+        # qsize = self._queue.async_q.qsize()
+        # print('qsize before:', qsize)
+        if not self._reject_new_events:
+            await self._queue.async_q.put(event)
+            LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
+
+        # qsize = self._queue.async_q.qsize()
+        # print('qsize after:', qsize)
 
         if event.name == "kytos/core.shutdown":
             LOG.info('[buffer: %s] Stop mode enabled. Rejecting new events.',
@@ -51,7 +77,21 @@ class KytosEventBuffer(object):
                 Event removed from top of queue.
 
         """
-        event = self._queue.get()
+        event = self._queue.sync_q.get()
+
+        LOG.debug('[buffer: %s] Removed: %s', self.name, event.name)
+
+        return event
+
+    async def aget(self):
+        """Remove and return a event from top of queue.
+
+        Returns:
+            :class:`~kytos.core.events.KytosEvent`:
+                Event removed from top of queue.
+
+        """
+        event = await self._queue.async_q.get()
 
         LOG.debug('[buffer: %s] Removed: %s', self.name, event.name)
 
@@ -65,26 +105,26 @@ class KytosEventBuffer(object):
         processed (meaning that a task_done() call was received for every item
         that had been put() into the KytosEventBuffer).
         """
-        self._queue.task_done()
+        self._queue.sync_q.task_done()
 
     def join(self):
         """Block until all events are gotten and processed.
 
         A item is processed when the method task_done is called.
         """
-        self._queue.join()
+        self._queue.sync_q.join()
 
     def qsize(self):
         """Return the size of KytosEventBuffer."""
-        return self._queue.qsize()
+        return self._queue.sync_q.qsize()
 
     def empty(self):
         """Return True if KytosEventBuffer is empty."""
-        return self._queue.empty()
+        return self._queue.sync_q.empty()
 
     def full(self):
         """Return True if KytosEventBuffer is full of KytosEvent."""
-        return self._queue.full()
+        return self._queue.sync_q.full()
 
 
 class KytosBuffers(object):

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -105,5 +105,9 @@ def run_on_thread(method):
     def threaded_method(*args):
         """Ensure the handler method runs inside a new thread."""
         thread = Thread(target=method, args=args)
+
+        # Set daemon mode so that we don't have to wait for these threads
+        # to finish when exiting Kytos
+        thread.daemon = True
         thread.start()
     return threaded_method

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3.6
 """Start Kytos SDN Platform core."""
+import asyncio
+import functools
 import signal
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 import daemon
 from IPython.terminal.embed import InteractiveShellEmbed
@@ -20,19 +23,20 @@ class KytosPrompt(Prompts):
         return [(Token.Prompt, 'kytos $> ')]
 
 
-def start_shell(controller):
+def start_shell(controller=None):
     """Load Kytos interactive shell."""
-    # pylint: disable=anomalous-backslash-in-string
-    banner1 = """\033[95m
+    kytos_ascii = r"""
       _          _
      | |        | |
      | | ___   _| |_ ___  ___
      | |/ / | | | __/ _ \/ __|
-     |   <| |_| | || (_) \__ \\
-     |_|\_\\\\__, |\__\___/|___/
+     |   <| |_| | || (_) \__ \
+     |_|\_\__,  |\__\___/|___/
             __/ |
            |___/
-    \033[0m
+    """
+
+    banner1 = f"""\033[95m{kytos_ascii}\033[0m
     Welcome to Kytos SDN Platform!
 
     We are making a huge effort to make sure that this console will work fine
@@ -44,16 +48,24 @@ def start_shell(controller):
 
     exit_msg = "Stopping Kytos daemon... Bye, see you!"
 
-    address = controller.server.server_address[0]
-    port = controller.server.server_address[1]
-    banner1 += " tcp://{}:{}\n".format(address, port)
+    if controller:
+        address = controller.server.server_address[0]
+        port = controller.server.server_address[1]
+        banner1 += f" tcp://{address}:{port}\n"
 
-    api_port = controller.api_server.port
-    banner1 += "    WEB UI........: http://{}:{}/".format(address, api_port)
+        api_port = controller.api_server.port
+        banner1 += f"    WEB UI........: http://{address}:{api_port}/"
+
+    banner1 += "\n"
 
     cfg = Config()
     cfg.TerminalInteractiveShell.autocall = 2
     cfg.TerminalInteractiveShell.show_rewritten_input = False
+    cfg.TerminalInteractiveShell.confirm_exit = False
+
+    # Avoiding sqlite3.ProgrammingError when trying to save command history
+    # on Kytos shutdown
+    cfg.HistoryAccessor.enabled = False
 
     ipshell = InteractiveShellEmbed(config=cfg,
                                     banner1=banner1,
@@ -63,17 +75,82 @@ def start_shell(controller):
     ipshell()
 
 
+# def disable_threadpool_exit():
+#     """Avoid traceback when ThreadPool tries to shut down threads again."""
+#     import atexit
+#     from concurrent.futures import thread, ThreadPoolExecutor
+#     atexit.unregister(thread._python_exit)
+
+
+def async_main():
+    """Start main Kytos Daemon with asyncio loop."""
+    def stop_controller(controller):
+        """Stop the controller before quitting."""
+        loop = asyncio.get_event_loop()
+
+        # If stop() hangs, old ctrl+c behaviour will be restored
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)
+
+        # disable_threadpool_exit()
+
+        controller.log.info("Stopping Kytos controller...")
+        controller.stop()
+
+    async def start_shell_async():
+        """Run the shell inside a thread and stop controller when done."""
+        _start_shell = functools.partial(start_shell, controller)
+        data = await loop.run_in_executor(executor, _start_shell)
+        executor.shutdown()
+        stop_controller(controller)
+        return data
+
+    config = KytosConfig()
+    controller = Controller(config.options['daemon'])
+
+    loop = asyncio.get_event_loop()
+    kill_handler = functools.partial(stop_controller, controller)
+    loop.add_signal_handler(signal.SIGINT, kill_handler)
+    loop.add_signal_handler(signal.SIGTERM, kill_handler)
+
+    if controller.options.debug:
+        loop.set_debug(True)
+
+    if controller.options.foreground:
+        try:
+            controller.start()
+        except SystemExit as exc:
+            controller.log.error(exc)
+            controller.log.info("Kytos start aborted.")
+            sys.exit()
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        loop.create_task(start_shell_async())
+    else:
+        with daemon.DaemonContext():
+            try:
+                controller.start()
+            except SystemExit as exc:
+                controller.log.error(exc)
+                controller.log.info("Kytos daemon start aborted.")
+                sys.exit()
+
+
 def main():
     """Start main Kytos Daemon."""
     def stop_controller(signum, frame):     # pylint: disable=unused-argument
         """Stop the controller before quitting."""
         if controller:
             print('Stopping controller...')
+
             # If stop() hangs, old ctrl+c behaviour will be restored
-            signal.signal(signal.SIGINT, kill_handler)
+            signal.signal(signal.SIGINT, sigint_handler)
+            signal.signal(signal.SIGTERM, sigkill_handler)
+
             controller.stop()
 
-    kill_handler = signal.signal(signal.SIGINT, stop_controller)
+    sigint_handler = signal.signal(signal.SIGINT, stop_controller)
+    sigkill_handler = signal.signal(signal.SIGTERM, stop_controller)
 
     config = KytosConfig()
     controller = Controller(config.options['daemon'])
@@ -88,6 +165,7 @@ def main():
 
         start_shell(controller)
 
+        # Stop Kytos controller after user exits shell
         controller.stop()
     else:
         with daemon.DaemonContext():

--- a/requirements/run.in
+++ b/requirements/run.in
@@ -11,5 +11,6 @@ python-daemon>=2.1.2
 # For some reason setuptools
 # Maybe we need to remove this on the future
 setuptools>=34.0.0
+janus
 jinja2
 watchdog


### PR DESCRIPTION
API Server, ipython, event handlers and event notifications are still
running on separate threads.

* New lib requirement: janus, for async+sync queues
* Now Kytos calls controller.stop() on SIGTERM
* Set daemon mode on threads created by @listen_to to avoiding locking
* Shorter names for modules on log messages

Known issues:
* No IPython history between sessions, to avoid SQLite error w/ threads