### PR TITLE
Added get_metadata_as_dict

### DIFF
--- a/kytos/core/common.py
+++ b/kytos/core/common.py
@@ -76,6 +76,14 @@ class GenericEntity:
         """Try to get a specific metadata."""
         return self.metadata.get(key)
 
+    def get_metadata_as_dict(self):
+        """Get all metadata values as dict."""
+        metadata = dict(self.metadata)
+        for key, value in self.metadata.items():
+            if hasattr(value, 'as_dict'):
+                metadata[key] = value.as_dict()
+        return metadata
+
     def update_metadata(self, key, value):
         """Overwrite a specific metadata."""
         self.metadata[key] = value

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -88,7 +88,7 @@ class Link(GenericEntity):
         return {'id': self.id,
                 'endpoint_a': self.endpoint_a.as_dict(),
                 'endpoint_b': self.endpoint_b.as_dict(),
-                'metadata': self.metadata,
+                'metadata': self.get_metadata_as_dict(),
                 'active': self.active,
                 'enabled': self.enabled}
 


### PR DESCRIPTION
It turns out, mef_eline adds a TAG object on `metadata['s_vlan']`, and we can't serialize via JSON, so this PR fixes this:

```
  - DEBUG [kytos/mef_eline:168] (Thread-224) {'a23c61293dad462ebdfc25527ba9e6c0': {'id': 'a23c61293dad462ebdfc25527ba9e6c0', 'name': 's2-s3', 'uni_a': {'interface_id': '00:00:00:00:00:00:00:03:1', 'tag': {'tag_type': 1, 'value': 80}}, 'uni_z': {'interface_id': '00:00:00:00:00:00:00:02:1', 'tag': {'tag_type': 1, 'value': 80}}, 'start_date': '2018-05-13T20:38:16', 'end_date': None, 'bandwidth': 0, 'primary_links': [{'id': '7c119698-0c8a-4809-9c31-ce67f7aad165', 'endpoint_a': {'id': '00:00:00:00:00:00:00:03:2', 'name': 's3-eth2', 'port_number': 2, 'mac': 'b6:28:ec:c9:8f:ce', 'switch': '00:00:00:00:00:00:00:03', 'type': 'interface', 'nni': True, 'uni': False, 'speed': 1250000000.0, 'metadata': {}, 'active': True, 'enabled': True, 'link': '85cb1be8-f90a-40ff-b49e-e15bdd971503'}, 'endpoint_b': {'id': '00:00:00:00:00:00:00:02:3', 'name': 's2-eth3', 'port_number': 3, 'mac': '22:bf:2e:b7:9c:26', 'switch': '00:00:00:00:00:00:00:02', 'type': 'interface', 'nni': True, 'uni': False, 'speed': 1250000000.0, 'metadata': {}, 'active': True, 'enabled': True, 'link': '85cb1be8-f90a-40ff-b49e-e15bdd971503'}, 'metadata': {'s_vlan': <kytos.core.interface.TAG object at 0x7fe7bc5f8390>}, 'active': True, 'enabled': True}], 'backup_links': [], 'dynamic_backup_path': False, 'current_path': [], 'primary_path': [], 'backup_path': [], 'request_time': '2018-05-13T20:39:09', 'creation_time': '2018-05-13T20:38:16', 'owner': None, 'active': True, 'enabled': True, 'priority': 0}}
 - ERROR [flask.app:1761] (Thread-224) Exception on /api/kytos/mef_eline/v2/evc [GET]
Traceback (most recent call last):
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/var/lib/kytos/napps/kytos/mef_eline/main.py", line 169, in list_circuits
    return jsonify(circuits.data), 200
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/json/__init__.py", line 321, in jsonify
    dumps(data, indent=indent, separators=separators) + '\n',
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/json/__init__.py", line 179, in dumps
    rv = _json.dumps(obj, **kwargs)
  File "/usr/lib64/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib64/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.5/lib/python3.6/site-packages/flask/json/__init__.py", line 81, in default
    return _json.JSONEncoder.default(self, o)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'TAG' is not JSON serializable
```

Manual test after committing this change, note the `metadata['s_vlan']` as_dict below:

```
❯ curl -X GET http://localhost:8181/api/kytos/mef_eline/v2/evc
{"a84dc906db4c469fb56b96351ed29691":{"active":true,"backup_links":[],"backup_path":[],"bandwidth":0,"creation_time":"2018-05-13T21:09:52","current_path":[],"dynamic_backup_path":false,"enabled":true,"end_date ":null,"id":"a84dc906db4c469fb56b96351ed29691","name":"s2-s3","owner":null,"primary_links":[{"active":true,"enabled":true,"endpoint_a":{"active":true,"enabled":true,"id":"00:00:00:00:00:00:00:03:2","link":"7c90b3e2-484f-4fcb-88b3-d29a6b6f8dad","mac":"b6:28:ec:c9:8f:ce","metadata":{},"name":"s3-eth2","nni":true,"port_number":2,"speed":1250000000.0,"switch":"00:00:00:00:00:00:00:03","type":"interface","uni":false}, "endpoint_b":{"active":true,"enabled":true,"id":"00:00:00:00:00:00:00:02:3","link":"7c90b3e2-484f-4fcb-88b3-d29a6b6f8dad","mac":"22:bf:2e:b7:9c:26","metadata":{},"name":"s2-eth3","nni":true,"port_number":3,"s peed":1250000000.0,"switch":"00:00:00:00:00:00:00:02","type":"interface","uni":false},"id":"d2672378-361a-4e36-9d9c-a1599ede833e","metadata":{"s_vlan":{"tag_type":1,"value":1}}}],"primary_path":[],"priority": 0,"request_time":"2018-05-13T21:09:52","start_date":"2018-05-13T21:09:52","uni_a":{"interface_id":"00:00:00:00:00:00:00:03:1","tag":{"tag_type":1,"value":80}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:02:1","tag":{"tag_type":1,"value":80}}}}
```
