### PR TITLE
Added send_event on controller.py

### DIFF
--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -703,3 +703,13 @@ class Controller(object):
         # items from it.
         for (username, napp_name) in list(self.napps.keys()):  # noqa
             self.unload_napp(username, napp_name)
+
+    def send_event(self, name, content):
+        """Send KytosEvent to other NApps.
+
+        Args:
+            name (str): KytosEvent name
+            content (dict): KytosEvent content payload
+
+        """
+        self.buffers.app.put(KytosEvent(name, content))


### PR DESCRIPTION
Hi team, whenever a NApp developer wanted to send an event to other NApp, he needed to import KytosEvent and put the event in the queue. I believe this detail of putting the event in the queue should be abstracted to the NApp developer. So, this PR adds a function `send_event(name, content)` to address this. The developer only needs to write a single line to send a KytosEvent to other Napps now:

```
self.controller.send_event(event_name, content)
```

For example, on these three NApps (topology, flow_manager and mef_eline) you can see this repeated pattern:

```
kytos/topology/main.py
6:from kytos.core import KytosEvent, KytosNApp, log, rest
414:        event = KytosEvent(name=name, content={'topology':
416:        self.controller.buffers.app.put(event)
431:        event = KytosEvent(name=name, content={entity: obj,
433:        self.controller.buffers.app.put(event)

kytos/flow_manager/main.py
135:        event_app = KytosEvent(name, content)
136:        self.controller.buffers.app.put(event_app)

kytos/mef_eline/main.py
12:from kytos.core.events import KytosEvent
242:        event = KytosEvent(name=name, content=content)
243:        self.controller.buffers.app.put(event)
268:        event = KytosEvent(name=name, content=content)
269:        self.controller.buffers.app.put(event)
292:        event = KytosEvent(name=name, content=content)
293:        self.controller.buffers.app.put(event)
367:        event = KytosEvent(name=name, content=content)
368:        self.controller.buffers.app.put(event)
```
