### PR TITLE
Allow users to pre-install NApps.

### DIFF
--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -55,6 +55,9 @@ class KytosConfig():
                             action='store',
                             help="Specify the napps directory")
 
+        parser.add_argument('-N', '--napps_installed',
+                            help="NApps to be installed. JSON list format.")
+
         parser.add_argument('-P', '--port',
                             action='store',
                             help="Port to be listened")
@@ -95,6 +98,7 @@ class KytosConfig():
                         'foreground': False,
                         'protocol_name': '',
                         'enable_entities_by_default': False,
+                        'napps_installed': "[]",
                         'debug': False}
 
         """
@@ -113,6 +117,7 @@ class KytosConfig():
                     'foreground': False,
                     'protocol_name': '',
                     'enable_entities_by_default': False,
+                    'napps_installed': "[]",
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()
@@ -145,6 +150,8 @@ class KytosConfig():
         """
         options = self.parser.parse_args(argv)
         options.napps_repositories = json.loads(options.napps_repositories)
+        options.napps_installed = options.napps_installed.replace('\'', '"')
+        options.napps_installed = json.loads(options.napps_installed)
         options.debug = True if options.debug in ['True', True] else False
         options.daemon = True if options.daemon in ['True', True] else False
         options.port = int(options.port)

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -236,7 +236,7 @@ class Controller(object):
 
         self.log.info("Loading Kytos NApps...")
         self.napp_dir_listener.start()
-        self.load_napps()
+        self.load_napps(self.options.napps_installed)
 
         self.started_at = now()
 
@@ -648,10 +648,18 @@ class Controller(object):
             self.events_listeners.setdefault(event, []).extend(listeners)
         # pylint: enable=protected-access
 
-    def load_napps(self):
-        """Load all NApps enabled on the NApps dir."""
-        napps = NAppsManager(self)
-        for napp in napps.list_enabled():
+    def load_napps(self, napps=None):
+        """Load all NApps enabled on the NApps dir.
+
+        Args:
+            napps ([str]): napps to be installed.
+
+        """
+        napps_mngr = NAppsManager(self)
+        if isinstance(napps, list):
+            for napp in napps:
+                napps_mngr.install(napp)
+        for napp in napps_mngr.list_enabled():
             try:
                 self.log.info("Loading NApp %s", napp.id)
                 self.load_napp(napp.username, napp.name)


### PR DESCRIPTION


This PR allows the user to pre-install napps when first spawning kytos. AmLight team would like this feature, which allows an easy installation without having to keep messing with the CLI after kytos is loaded to install NApps, or performing rest calls to do so. Plus, I believe this is a feature we need for integration tests (for example, I want to run integration tests between two NApps, and I need kytos pre-install both of them, and they're not necessarily dependencies of each other, but they're NApps that are supposed to run in parallel). FYI, other controllers such as ONOS also has this feature.

## Pre-installing NApps

```
❯ kytosd -f -E -N "['kytos/of_core', 'viniciusarcanjo/kyslacker']"
2018-05-19 11:22:37,194 - INFO [controller:237] (MainThread) Loading Kytos NApps...
2018-05-19 11:22:37,195 - INFO [kytos.core.napps.napp_dir_listener:40] (MainThread) NAppDirListener Started...
2018-05-19 11:22:37,200 - WARNING [kytos.core.napps.manager:89] (MainThread) Unable to install NApp kytos/of_core. Already installed.
2018-05-19 11:22:38,508 - INFO [kytos.core.napps.manager:106] (MainThread) New NApp installed: viniciusarcanjo/kyslacker
```

## Default args (not pre-installing anything)

```
❯ kytosd -f -E
2018-05-19 11:25:04,956 - INFO [controller:231] (MainThread) ThreadPool started: <concurrent.futures.thread.ThreadPoolExecutor object at 0x7fbdf0564b00>
2018-05-19 11:25:04,956 - INFO [controller:237] (MainThread) Loading Kytos NApps...
2018-05-19 11:25:04,959 - INFO [kytos.core.napps.napp_dir_listener:40] (MainThread) NAppDirListener Started...
```

Let me know what you think.

Thanks, guys!
