### PR TITLE
Added __repr__ on NApp class

### DIFF
--- a/kytos/core/napps/base.py
+++ b/kytos/core/napps/base.py
@@ -34,6 +34,9 @@ class NApp:
     def __str__(self):
         return "{}/{}".format(self.username, self.name)
 
+    def __repr__(self):
+        return f"NApp({self.username}/{self.name})"
+
     def __hash__(self):
         return hash(self.id)
 


### PR DESCRIPTION
I was debugging a NApp and it turns out that having the __repr__ method was quite handy. Let me know if this should be merged.