### PR TITLE
Pre install napps

### DIFF
--- a/etc/kytos/kytos.conf.template
+++ b/etc/kytos/kytos.conf.template
@@ -51,3 +51,7 @@ napps = {{ prefix }}/var/lib/kytos/napps
 napps_repositories = [
     "https://napps.kytos.io/repo/"
     ]
+
+# Pre installed napps. List of Napps to be pre-installed and enabled.
+# Use double quotes in each NApp in the list, e.g., ["username/napp"].
+napps_pre_installed = []

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -113,6 +113,7 @@ class KytosConfig():
                     'foreground': False,
                     'protocol_name': '',
                     'enable_entities_by_default': False,
+                    'napps_pre_installed': [],
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()
@@ -153,5 +154,6 @@ class KytosConfig():
 
         result = options.enable_entities_by_default in ['True', True]
         options.enable_entities_by_default = result
+        options.napps_pre_installed = json.loads(options.napps_pre_installed)
 
         return options

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -236,6 +236,7 @@ class Controller(object):
 
         self.log.info("Loading Kytos NApps...")
         self.napp_dir_listener.start()
+        self.pre_install_napps(self.options.napps_pre_installed)
         self.load_napps()
 
         self.started_at = now()
@@ -670,6 +671,20 @@ class Controller(object):
         for event, listeners in napp._listeners.items():
             self.events_listeners.setdefault(event, []).extend(listeners)
         # pylint: enable=protected-access
+
+    def pre_install_napps(self, napps, enable=True):
+        """Pre install and enable NApps.
+
+        Before installing, it'll check if it's installed yet.
+
+        Args:
+            napps ([str]): List of NApps to be pre-installed and enabled.
+        """
+        napps_mngr = NAppsManager(self)
+        installed = [str(napp) for napp in napps_mngr.list()]
+        napps_diff = [napp for napp in napps if napp not in installed]
+        for napp in napps_diff:
+            napps_mngr.install(napp, enable=enable)
 
     def load_napps(self):
         """Load all NApps enabled on the NApps dir."""

--- a/kytos/core/napps/base.py
+++ b/kytos/core/napps/base.py
@@ -24,7 +24,7 @@ class NApp:
                  repository=None):
         self.username = username
         self.name = name
-        self.version = version
+        self.version = version if version else 'latest'
         self.repository = repository
         self.description = None
         self.tags = []


### PR DESCRIPTION
This is to address #740. I'm using the kytos.conf file now. Two points regarding this change:

1 - I've added a new method `pre_install_napps`, since I felt like augumenting args on `load_napps` on controller.py would make that method to two things as opposed to a only load napps.
2 - I've changed NApp.version as 'default'. I realized this was needed, since if you pass a short string URI like 'user/napp' to NApp.from_uri, then the version was set as None, which caused an issue, since the NApp wouldn't have the proper uri to be downloaded from kytos.napps.io. And, looking back on the codebase it looks like the default is meant to be 'latest' when a version is not explicitly set. 

Tests:

On kytos.conf:

```
...
# Pre installed napps. List of Napps to be pre-installed and enabled.
# Use double quotes in each NApp in the list, e.g., ["user/napp"]
napps_pre_installed = ["viniciusarcanjo/kyslacker"]
```

Result:
```
2018-05-28 07:31:24,275 - INFO [controller:237] (MainThread) Loading Kytos NApps...
2018-05-28 07:31:24,277 - INFO [kytos.core.napps.napp_dir_listener:40] (MainThread) NAppDirListener Started...
2018-05-28 07:31:25,604 - INFO [kytos.core.napps.manager:106] (MainThread) New NApp installed: viniciusarcanjo/kyslacker
```

On kytos.conf (default): nothing happens
```
napps_pre_installed = []
```

Result:
```
2018-05-28 07:38:10,110 - INFO [controller:237] (MainThread) Loading Kytos NApps...
2018-05-28 07:38:10,112 - INFO [kytos.core.napps.napp_dir_listener:40] (MainThread) NAppDirListener Started...
2018-05-28 07:38:10,117 - INFO [controller:694] (MainThread) Loading NApp kytos/of_lldp
```
