### PR TITLE
Unit tests connecting to TCP server (ref #795)

### DIFF
--- a/kytos/core/atcp_server.py
+++ b/kytos/core/atcp_server.py
@@ -26,14 +26,15 @@ class KytosServer:
     It creates a new thread for each Handler.
     """
 
-    def __init__(self, server_address, server_protocol, controller,
-                 protocol_name):
+    def __init__(self,  # pylint: disable=too-many-arguments
+                 server_address, server_protocol, controller,
+                 protocol_name, loop=None):
         """Create the object without starting the server.
 
         Args:
             server_address (tuple): Address where the server is listening.
                 example: ('127.0.0.1', 80)
-            server_protocol(asyncio.Protocol):
+            server_protocol (asyncio.Protocol):
                 Class that will be instantiated to handle each request.
             controller (:class:`~kytos.core.controller.Controller`):
                 An instance of Kytos Controller class.
@@ -52,7 +53,7 @@ class KytosServer:
         # object pointing to this instance
         self.server_protocol.server = self
 
-        self.loop = asyncio.get_event_loop()
+        self.loop = loop or asyncio.get_event_loop()
         self.loop.set_exception_handler(exception_handler)
 
     def serve_forever(self):

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 class KytosEventBuffer:
     """KytosEventBuffer represents a queue to store a set of KytosEvents."""
 
-    def __init__(self, name, event_base_class=None):
+    def __init__(self, name, event_base_class=None, loop=None):
         """Contructor of KytosEventBuffer receive the parameters below.
 
         Args:
@@ -22,8 +22,9 @@ class KytosEventBuffer:
             event_base_class (class): Class of KytosEvent.
         """
         self.name = name
-        self._queue = Queue()
         self._event_base_class = event_base_class
+        self._loop = loop
+        self._queue = Queue(loop=self._loop)
         self._reject_new_events = False
 
     def put(self, event):
@@ -130,7 +131,7 @@ class KytosEventBuffer:
 class KytosBuffers:
     """Set of KytosEventBuffer used in Kytos."""
 
-    def __init__(self):
+    def __init__(self, loop=None):
         """Build four KytosEventBuffers.
 
         :attr:`raw`: :class:`~kytos.core.buffers.KytosEventBuffer` with events
@@ -145,10 +146,11 @@ class KytosBuffers:
         :attr:`app`: :class:`~kytos.core.buffers.KytosEventBuffer` with events
         sent to NApps.
         """
-        self.raw = KytosEventBuffer('raw_event')
-        self.msg_in = KytosEventBuffer('msg_in_event')
-        self.msg_out = KytosEventBuffer('msg_out_event')
-        self.app = KytosEventBuffer('app_event')
+        self._loop = loop
+        self.raw = KytosEventBuffer('raw_event', loop=self._loop)
+        self.msg_in = KytosEventBuffer('msg_in_event', loop=self._loop)
+        self.msg_out = KytosEventBuffer('msg_out_event', loop=self._loop)
+        self.app = KytosEventBuffer('app_event', loop=self._loop)
 
     def send_stop_signal(self):
         """Send a ``kytos/core.shutdown`` event to each buffer."""

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -57,7 +57,7 @@ class Controller:
 
     # Created issue #568 for the disabled checks.
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
-    def __init__(self, options=None):
+    def __init__(self, options=None, loop=None):
         """Init method of Controller class takes the parameters below.
 
         Args:
@@ -66,10 +66,14 @@ class Controller:
         """
         if options is None:
             options = KytosConfig().options['daemon']
+
+        self._loop = loop or asyncio.get_event_loop()
+        self._pool = ThreadPoolExecutor(max_workers=1)
+
         #: dict: keep the main threads of the controller (buffers and handler)
         self._threads = {}
         #: KytosBuffers: KytosBuffer object with Controller buffers
-        self.buffers = KytosBuffers()
+        self.buffers = KytosBuffers(loop=self._loop)
         #: dict: keep track of the socket connections labeled by ``(ip, port)``
         #:
         #: This dict stores all connections between the controller and the
@@ -114,9 +118,6 @@ class Controller:
 
         #: Observer that handle NApps when they are enabled or disabled.
         self.napp_dir_listener = NAppDirListener(self)
-
-        self._loop = asyncio.get_event_loop()
-        self._pool = ThreadPoolExecutor(max_workers=1)
 
         #: Adding the napps 'enabled' directory into the PATH
         #: Now you can access the enabled napps with:

--- a/tests/test_core/test_atcp_server.py
+++ b/tests/test_core/test_atcp_server.py
@@ -1,5 +1,6 @@
 """Async TCP Server tests."""
 
+import asyncio
 import logging
 import unittest
 
@@ -10,19 +11,29 @@ from kytos.core.atcp_server import KytosServer, KytosServerProtocol
 
 logging.basicConfig(level=logging.CRITICAL)
 
+# Using "nettest" TCP port as a way to avoid conflict with a running
+# Kytos server on 6633.
+TEST_ADDRESS = ('127.0.0.1', 4138)
+
 
 class TestKytosServer(unittest.TestCase):
-    """Test Kytos TCP Server."""
-
+    """"Test if a Kytos Server will go up and receive connections."""
     def setUp(self):
-        """Create server object."""
-        self.server = KytosServer('127.0.0.1', KytosServerProtocol,
-                                  None, 'openflow')
-
-    def test_init(self):
-        """Test initialization."""
-        assert isinstance(self.server, KytosServer)
-
-    def test_serve_forever(self):
-        """Test main server method."""
+        """Start new asyncio loop and a test TCP server."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+        self.server = KytosServer(TEST_ADDRESS, KytosServerProtocol,
+                                  None, 'openflow', loop=self.loop)
         self.server.serve_forever()
+
+    def test_connection_to_server(self):
+        """Test if we really can connect to TEST_ADDRESS."""
+        @asyncio.coroutine
+        def wait_and_go():
+            """Wait a little for the server to go up, then connect."""
+            yield from asyncio.sleep(0.01, loop=self.loop)
+            # reader, writer = ...
+            _ = yield from asyncio.open_connection(
+                *TEST_ADDRESS, loop=self.loop)
+
+        self.loop.run_until_complete(wait_and_go())

--- a/tests/test_core/test_controller.py
+++ b/tests/test_core/test_controller.py
@@ -1,4 +1,5 @@
 """Test kytos.core.controller module."""
+import asyncio
 import json
 import logging
 import warnings
@@ -15,8 +16,12 @@ class TestController(TestCase):
 
     def setUp(self):
         """Instantiate a controller."""
+
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
         self.options = KytosConfig().options['daemon']
-        self.controller = Controller(self.options)
+        self.controller = Controller(self.options, loop=self.loop)
         self.controller.log = Mock()
 
     def test_configuration_endpoint(self):
@@ -31,13 +36,16 @@ class TestController(TestCase):
     @patch('kytos.core.logs.Path')
     def test_websocket_log_usage(path, log_manager):
         """Assert that the web socket log is used."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
         # Save original state
         handlers_bak = copy(logging.root.handlers)
 
         # Minimum to instantiate Controller
         options = Mock(napps='')
         path.return_value.exists.return_value = False
-        controller = Controller(options)
+        controller = Controller(options, loop=loop)
 
         # The test
         controller.enable_logs()


### PR DESCRIPTION
Tests now start a real TCP server and a client to test connection.

Added loop parameter to many asyncio-related classes,
so that we can control which loop will be used on tests.