### PR TITLE
Added set_available_tags to reuse VLAN pool configuration

### DIFF
--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -85,12 +85,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         self.stats = None
         self.link = None
         self._custom_speed = speed
-        self.available_tags = []
-
-        for i in range(1, 4096):
-            vlan = TAGType.VLAN
-            tag = TAG(vlan, i)
-            self.available_tags.append(tag)
+        self.set_available_tags(range(1, 4096))
 
         super().__init__()
 
@@ -119,6 +114,19 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     def uni(self):
         """Return if an interface is a user-to-network Interface."""
         return not self.nni
+
+    def set_available_tags(self, iterable):
+        """Set a range of VLAN tags to be used by this Interface.
+
+        Args:
+            iterable ([int]): range of VLANs.
+        """
+        self.available_tags = []
+
+        for i in iterable:
+            vlan = TAGType.VLAN
+            tag = TAG(vlan, i)
+            self.available_tags.append(tag)
 
     def enable(self):
         """Enable this interface instance.

--- a/tests/test_core/test_interface.py
+++ b/tests/test_core/test_interface.py
@@ -105,3 +105,14 @@ class TestInterface(unittest.TestCase):
         self.assertEqual(custom_speed, iface.speed)
         iface.set_custom_speed(None)
         self.assertEqual(of_speed, iface.speed)
+
+    def test_interface_available_tags(self):
+        """Test available_tags on Interface class."""
+        default_range = [vlan for vlan in range(1, 4096)]
+        intf_values = [tag.value for tag in self.iface.available_tags]
+        self.assertListEqual(intf_values, default_range)
+
+        custom_range = [vlan for vlan in range(100, 199)]
+        self.iface.set_available_tags(custom_range)
+        intf_values = [tag.value for tag in self.iface.available_tags]
+        self.assertListEqual(intf_values, custom_range)


### PR DESCRIPTION
I added this method to reuse the configuration of the available_tags. Related to https://github.com/kytos/mef_eline/issues/86