### PR TITLE
Added vlan_pool configuration on kytos.conf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Added
+=====
+ - Added vlan_pool configuration on kytos.conf to support mef_eline
+
 Changed
 =======
 

--- a/etc/kytos/kytos.conf.template
+++ b/etc/kytos/kytos.conf.template
@@ -55,3 +55,14 @@ napps_repositories = [
 # Pre installed napps. List of Napps to be pre-installed and enabled.
 # Use double quotes in each NApp in the list, e.g., ["username/napp"].
 napps_pre_installed = []
+
+# VLAN pool settings
+#
+# The VLAN pool settings is a dictionary of datapath id, which contains
+# a dictionary of of_port numbers with the respective vlan pool range
+# for each port number. See the example below, which sets the vlan range
+# [1, 5, 6, 7, 8, 9] on port 1 and vlan range [3] on port 4 of a switch
+# that has a dpid '00:00:00:00:00:00:00:01'
+
+vlan_pool = {}
+# vlan_pool = {"00:00:00:00:00:00:00:01": {"1": [[1, 2], [5, 10]], "4": [[3, 4]]}}

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -114,6 +114,7 @@ class KytosConfig():
                     'protocol_name': '',
                     'enable_entities_by_default': False,
                     'napps_pre_installed': [],
+                    'vlan_pool': {},
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -52,6 +52,9 @@ class TAG:
         """Return a json representating a tag object."""
         return json.dumps(self.as_dict())
 
+    def __repr__(self):
+        return f"TAG({self.tag_type!r}, {self.value!r})"
+
 
 class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     """Interface Class used to abstract the network interfaces."""

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -187,14 +187,21 @@ class Switch(GenericEntity):
         """Update the lastseen attribute."""
         self.lastseen = now()
 
-    def update_interface(self, interface):
-        """Update a interface from switch instance.
+    def update_interface(self, interface, attrs_filter=None):
+        """Update or associate a interface from switch instance.
 
         Args:
             interface (:class:`~kytos.core.switch.Interface`):
                 Interface object to be storeged.
+            attrs_filter ([str]): attributes to be updated.
+
         """
-        self.interfaces[interface.port_number] = interface
+        if not attrs_filter or not self.interfaces.get(interface.port_number):
+            self.interfaces[interface.port_number] = interface
+        else:
+            intf_ref = self.interfaces[interface.port_number]
+            for attr in attrs_filter:
+                setattr(intf_ref, attr, getattr(interface, attr))
 
     def remove_interface(self, interface):
         """Remove a interface from switch instance.

--- a/tests/test_core/test_switch.py
+++ b/tests/test_core/test_switch.py
@@ -1,0 +1,64 @@
+"""Test kytos.core.switch module."""
+import asyncio
+from unittest import TestCase
+from unittest.mock import Mock
+
+from kytos.core import Controller
+from kytos.core.config import KytosConfig
+from kytos.core.interface import Interface
+from kytos.core.switch import Switch
+
+
+class TestSwitch(TestCase):
+    """Switch tests."""
+
+    def setUp(self):
+        """Instantiate a controller."""
+
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+        self.options = KytosConfig().options['daemon']
+        self.controller = Controller(self.options, loop=self.loop)
+        self.controller.log = Mock()
+
+    def tearDown(self):
+        """TearDown."""
+        self.loop.close()
+
+    def test_switch_vlan_pool_default(self):
+        """Test default vlan_pool value."""
+        self.assertEqual(self.options.vlan_pool, {})
+
+    def test_switch_set_options_vlan_pool(self):
+        """Test switch with the example from kytos.conf."""
+        dpid = "00:00:00:00:00:00:00:01"
+        vlan_pool_json = '{"00:00:00:00:00:00:00:01": {"1": [[1, 2], [5, 10]], \
+            "4": [[3, 4]]}}'
+        switch = Switch(dpid)
+        self.controller.switches[dpid] = switch
+        self.options.vlan_pool = vlan_pool_json
+        switch.connection = Mock()
+        switch.connection.protocol.version = 0x04
+        self.controller.get_switch_or_create(dpid, switch.connection)
+
+        port_id = 1
+        intf = self.controller.switches[dpid].interfaces[port_id]
+        tag_values = [tag.value for tag in intf.available_tags]
+        self.assertEqual(tag_values, [1, 5, 6, 7, 8, 9])
+
+        port_id = 4
+        intf = self.controller.switches[dpid].interfaces[port_id]
+        tag_values = [tag.value for tag in intf.available_tags]
+        self.assertEqual(tag_values, [3])
+
+        # this port number doesn't exist yet.
+        port_7 = 7
+        intf = Interface("test", port_7, switch)
+        # no attr filters, so should associate as it is
+        self.controller.switches[dpid].update_interface(intf)
+        intf_obj = self.controller.switches[dpid].interfaces[port_7]
+        self.assertEqual(intf_obj, intf)
+        # assert default vlan_pool range (1, 4096)
+        tag_values = [tag.value for tag in intf_obj.available_tags]
+        self.assertEqual(tag_values, list(range(1, 4096)))


### PR DESCRIPTION
This PR changes the following to support mef_eline to have a custom vlan_pool settings. Based on our last discussions it would make more sense to have this settions on kytos.conf instead of the NApp itself:

- Added set_switch_options on controller.py
- Added repr on interface.TAG
- Adjusted update_interface on switch.py
- Added tests/test_core/test_switch.py
- Updated CHANGELOG.rst

From now on, whenever we need to instantiate an Interface object, the developer is free to choose if he wants to only update certain attrs or the whole object. Currently among (flow_manager,  mef_eline,  of_core,  of_l2ls,  of_lldp,  of_stats,  pathfinder,  storehouse,  topology), only `of_core` was overwriting Interface objects:

```
❯ rg 'Interface\(' -g "*.py" -L
mef_eline/tests/helpers.py
19:    endpoint_a = Interface(kwargs.get('endpoint_a_name', 'eth0'),
21:    endpoint_b = Interface(kwargs.get('endpoint_b_name', 'eth1'),
54:    interface = Interface(interface_name, interface_port, switch)

mef_eline/tests/models/test_evc_deploy.py
112:        interface_a = Interface('eth0', 1, Mock(spec=Switch))
113:        interface_z = Interface('eth1', 3, Mock(spec=Switch))

of_core/main.py
477:            interface = Interface(name=port.name.value,
487:            interface = Interface(name=port.name.value,

of_core/v0x04/utils.py
84:        interface = Interface(name=port.name.value,

of_core/v0x01/utils.py
60:        interface = Interface(name=port.name.value,
```

This PR can be merged without breaking any NApp, but for the vlan_pool to be effective, `of_core` should stop overwriting the object, I'll send another PR on of_core shortly.