### PR TITLE
Instruction to install 'requirements.txt' using pip3 to fix Sphinx v1.8.4

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,7 @@ command below.
 
 .. code-block:: sh
 
-  pip install -r requirements.txt
+  pip3 install -r requirements.txt
 
 Building documentation
 ======================


### PR DESCRIPTION
'requirements.txt' installed using pip can lead to some warnings while run "make dirhtml" related to Python 2.7.  To get rid of it just install "requirements.txt" using pip3 instead pip.