### PR TITLE
Fix method get_next_available_tag (fix #883)

### DIFF
--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -103,11 +103,10 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
 
     @property
     def id(self):  # pylint: disable=invalid-name
-        """Return id from Interface intance.
+        """Return id from Interface instance.
 
         Returns:
             string: Interface id.
-
         """
         return "{}:{}".format(self.switch.dpid, self.port_number)
 
@@ -138,11 +137,13 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         self._enabled = True
 
     def use_tag(self, tag):
-        """Remove a specific tag from available_tags if it is there."""
-        for available_tag in self.available_tags:
-            if tag == available_tag:
-                self.available_tags.remove(available_tag)
-                return True
+        """Remove a specific tag from available_tags if it is there.
+
+        Return False in case the tag is already removed.
+        """
+        if tag in self.available_tags:
+            self.available_tags.remove(tag)
+            return True
         return False
 
     def is_tag_available(self, tag):
@@ -150,7 +151,12 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         return tag in self.available_tags
 
     def get_next_available_tag(self):
-        """Return the next available tag if exists."""
+        """Get the next available tag from the interface.
+
+        Return the next available tag if exists and remove from the
+        available tags.
+        If no tag is available return False.
+        """
         try:
             return self.available_tags.pop()
         except IndexError:

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -115,21 +115,21 @@ class Link(GenericEntity):
         available_tags_b = self.endpoint_b.available_tags.copy()
 
         for tag in available_tags_a:
-            if tag in available_tags_b:
-                is_success = self.endpoint_a.use_tag(tag)
-                if not is_success:
-                    # Tag already in use. Try another tag.
-                    continue
+            # Tag does not exist in endpoint B. Try another tag.
+            if tag not in available_tags_b:
+                continue
 
-                is_success = self.endpoint_b.use_tag(tag)
-                if not is_success:
-                    # Tag already in use.
-                    # Return endpoint_a tag and try another tag.
-                    self.endpoint_a.make_tag_available(tag)
-                    continue
+            # Tag already in use. Try another tag.
+            if not self.endpoint_a.use_tag(tag):
+                continue
 
-                # Tag used successfully by both endpoints. Returning.
-                return tag
+            # Tag already in use in B. Mark the tag as available again.
+            if not self.endpoint_b.use_tag(tag):
+                self.endpoint_a.make_tag_available(tag)
+                continue
+
+            # Tag used successfully by both endpoints. Returning.
+            return tag
 
         return False
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -155,7 +155,8 @@ def test_concurrently(times):
                 """Call the test method."""
                 try:
                     test_func(*args, **kwargs)
-                except Exception:
+                except Exception as _e:
+                    exceptions.append(_e)
                     raise
             threads = []
             for _ in range(times):

--- a/tests/test_core/test_link.py
+++ b/tests/test_core/test_link.py
@@ -1,5 +1,6 @@
 """Link tests."""
 import logging
+import time
 import unittest
 from unittest.mock import Mock
 
@@ -49,3 +50,71 @@ class TestLink(unittest.TestCase):
         link1 = Link(self.iface1, self.iface2)
         link2 = Link(self.iface2, self.iface1)
         self.assertEqual(link1.id, link2.id)
+
+    def test_get_next_available_tag(self):
+        """Test get next available tags returns different tags"""
+        link = Link(self.iface1, self.iface2)
+        tag = link.get_next_available_tag()
+        next_tag = link.get_next_available_tag()
+
+        self.assertNotEqual(tag, next_tag)
+
+    def test_get_tag_multiple_calls(self):
+        """Test get next available tags returns different tags"""
+        link = Link(self.iface1, self.iface2)
+        tag = link.get_next_available_tag()
+        self.assertEqual(tag.value, 1)
+
+        next_tag = link.get_next_available_tag()
+        self.assertEqual(next_tag.value, 2)
+
+    def test_next_tag__with_use_tags(self):
+        """Test get next availabe tags returns different tags"""
+        link = Link(self.iface1, self.iface2)
+        tag = link.get_next_available_tag()
+        self.assertEqual(tag.value, 1)
+
+        is_available = link.is_tag_available(tag)
+        self.assertFalse(is_available)
+        link.use_tag(tag)
+
+    def test_tag_life_cicle(self):
+        """Test get next available tags returns different tags"""
+        link = Link(self.iface1, self.iface2)
+        tag = link.get_next_available_tag()
+        self.assertEqual(tag.value, 1)
+
+        is_available = link.is_tag_available(tag)
+        self.assertFalse(is_available)
+
+        link.make_tag_available(tag)
+        is_available = link.is_tag_available(tag)
+        self.assertTrue(is_available)
+
+    def test_concurrent_get_next_tag(self):
+        """Test get next available tags in concurrent execution"""
+        from tests.helper import test_concurrently
+        _link = Link(self.iface1, self.iface2)
+
+        _i = []
+
+        @test_concurrently(20)
+        def test_get_next_available_tag():
+            """Test get next availabe tags returns different tags"""
+            _i.append(1)
+            _i_len = len(_i)
+            tag = _link.get_next_available_tag()
+            time.sleep(0.0001)
+            _link.use_tag(tag)
+
+            next_tag = _link.get_next_available_tag()
+            _link.use_tag(next_tag)
+
+            self.assertNotEqual(tag, next_tag)
+
+            # Check if in the 20 iteration the tag value is 40
+            # It happens because we get 2 tags for every iteration
+            if _i_len == 20:
+                self.assertEqual(next_tag.value, 40)
+
+        test_get_next_available_tag()


### PR DESCRIPTION
Fix the method get_next_available_tag to get and use the tag in single
 step. Deprecated the method use_tag, but maintained the behavior of the
 workflow using get tag / use tag.
Fix linter messages.