### PR TITLE
Add string repr's to Switch and Interface

### DIFF
--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -131,7 +131,7 @@ class KytosConfig():
         self.parser.set_defaults(**defaults)
 
         if 'test' in argv:
-            argv.pop(argv.index('test'))
+            argv.remove('test')
 
         self.options['daemon'] = self._parse_options(argv)
 

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -92,6 +92,9 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
 
         super().__init__()
 
+    def __repr__(self):
+        return f"Interface('{self.name}', {self.port_number}, {self.switch!r})"
+
     def __eq__(self, other):
         """Compare Interface class with another instance."""
         if isinstance(other, str):

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -83,6 +83,7 @@ def start_shell(controller=None):
 #     atexit.unregister(thread._python_exit)
 
 def main():
+    """Read config and start Kytos in foreground or daemon mode."""
     config = KytosConfig().options['daemon']
 
     if config.foreground:
@@ -139,4 +140,3 @@ def async_main(config):
         controller.log.info("Shutting down Kytos...")
     finally:
         loop.close()
-

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -84,6 +84,9 @@ class Switch(GenericEntity):
 
         super().__init__()
 
+    def __repr__(self):
+        return f"Switch('{self.dpid}')"
+
     def update_description(self, desc):
         """Update switch'descriptions from Switch instance.
 

--- a/requirements/run.in
+++ b/requirements/run.in
@@ -7,9 +7,6 @@ flask-socketio
 flask_cors
 flask
 python-daemon
-# For some reason setuptools
-# Maybe we need to remove this on the future
-setuptools>=34.0.0
 janus
 jinja2
 watchdog

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ setup(name='kytos',
       packages=find_packages(exclude=['tests']),
       install_requires=[line.strip()
                         for line in open("requirements/run.in").readlines()
-                        if not line.startswith('#') ],
+                        if not line.startswith('#')],
       extras_require={
           'dev': [
               'coverage',

--- a/tests/test_core/test_interface.py
+++ b/tests/test_core/test_interface.py
@@ -18,6 +18,11 @@ class TestInterface(unittest.TestCase):
         """Create interface object."""
         self.iface = self._get_v0x04_iface()
 
+    def test_repr(self):
+        """Test repr() output."""
+        expected = "Interface('name', 42, Switch('dpid'))"
+        self.assertEqual(repr(self.iface), expected)
+
     @staticmethod
     def _get_v0x04_iface(*args, **kwargs):
         """Create a v0x04 interface object with optional extra arguments."""

--- a/tests/test_core/test_switch.py
+++ b/tests/test_core/test_switch.py
@@ -22,6 +22,11 @@ class TestSwitch(TestCase):
         self.controller = Controller(self.options, loop=self.loop)
         self.controller.log = Mock()
 
+    def test_repr(self):
+        """Test repr() output."""
+        switch = Switch('some-dpid')
+        self.assertEqual(repr(switch), "Switch('some-dpid')")
+
     def tearDown(self):
         """TearDown."""
         self.loop.close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
+#envlist = py36,py37
 envlist = py36
 
 [testenv]
 whitelist_externals=
-  rm
+    rm
 
 commands=
     ; Force packaging even if setup.{py,cfg} haven't changed


### PR DESCRIPTION
Sometimes `of_core` prints an `Interface` and the default Python repr is being printed (a memory address id). This PR replaces that with something more useful like the Interface name, port number and switch dpid.