### PR TITLE
Fix qualname logging bug.

### DIFF
--- a/etc/kytos/logging.ini.template
+++ b/etc/kytos/logging.ini.template
@@ -29,6 +29,7 @@ handlers: syslog,console
 
 [logger_kytos]
 level: INFO
+qualname: kytos
 handlers: syslog,console
 
 [logger_api_server]


### PR DESCRIPTION
logger_kytos qualname was missing in logging.ini
Fix issue #963 