### PR TITLE
Merge pull request #1028 from gleybersonandrade/fix-coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,7 @@ filter:
         - 'kytos/web-ui/*'
 build:
     environment:
-        python: 3.6.0
+        python: 3.6.3
         postgresql: false
         redis: false
     dependencies:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ babel==2.6.0              # via sphinx
 certifi==2018.8.13        # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
-coverage==4.5.1
+coverage==5.0.3
 docopt==0.6.2             # via yala
 docutils==0.15.2          # via sphinx
 idna==2.7                 # via requests


### PR DESCRIPTION
The coverage version of requirements and python version of scrutinizer.yml was creating an error when running Scrutinizer. This commit changes coverage version from 4.5.1 to 5.0.3 and update python version from 3.6.0 to 3.6.3.