### PR TITLE
Create from_dict method for Interface, UNI, Switch and Link

### DIFF
--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -418,6 +418,17 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             iface_dict['stats'] = self.stats.as_dict()
         return iface_dict
 
+    @classmethod
+    def from_dict(cls, interface_dict):
+        """Return a Interface instance from python dictionary."""
+        return cls(interface_dict.get('name'),
+                   interface_dict.get('port_number'),
+                   interface_dict.get('switch'),
+                   interface_dict.get('address'),
+                   interface_dict.get('state'),
+                   interface_dict.get('features'),
+                   interface_dict.get('speed'))
+
     def as_json(self):
         """Return a json with Interfaces attributes.
 
@@ -464,6 +475,12 @@ class UNI:
             'interface_id': self.interface.id,
             'tag': self.user_tag.as_dict() if self.user_tag else None
             }
+
+    @classmethod
+    def from_dict(cls, uni):
+        """Return a Uni instance from python dictionary."""
+        return cls(uni.get('interface'),
+                   uni.get('user_tag'))
 
     def as_json(self):
         """Return a json representating a UNI object."""

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -61,7 +61,7 @@ class TAG:
 class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     """Interface Class used to abstract the network interfaces."""
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-public-methods
     def __init__(self, name, port_number, switch, address=None, state=None,
                  features=None, speed=None, config=None):
         """Assign the parameters to instance attributes.

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -170,3 +170,9 @@ class Link(GenericEntity):
     def as_json(self):
         """Return the Link as a JSON string."""
         return json.dumps(self.as_dict())
+
+    @classmethod
+    def from_dict(cls, link_dict):
+        """Return a Link instance from python dictionary."""
+        return cls(link_dict.get('endpoint_a'),
+                   link_dict.get('endpoint_b'))

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -353,3 +353,10 @@ class Switch(GenericEntity):
 
         """
         return json.dumps(self.as_dict())
+
+    @classmethod
+    def from_dict(cls, switch_dict):
+        """Return a Switch instance from python dictionary."""
+        return cls(switch_dict.get('dpid'),
+                   switch_dict.get('connection'),
+                   switch_dict.get('features'))


### PR DESCRIPTION
Some classes, like Interface, UNI, Switch and Link do not have a from_dict method. This commit solves this problem.

Related https://github.com/kytos/kytos/issues/1043