### PR TITLE
Link.get_next_available_tag() raise an exception when there is no available tag

### DIFF
--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -57,6 +57,26 @@ class KytosWrongEventType(KytosEventException):
     that buffer.
     """
 
+
+class KytosNoTagAvailableError(Exception):
+    """Exception raised when a link has no vlan available."""
+
+    def __init__(self, link):
+        """Require a link.
+
+        Args:
+            link (:class:`~kytos.core.link.Link`): A link with no vlan
+            available.
+        """
+        super().__init__()
+        self.link = link
+
+    def __str__(self):
+        """Full message."""
+        msg = f'Link {self.link.id} has no vlan available.'
+        return msg
+
+
 # Exceptions related  to NApps
 
 

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -9,6 +9,7 @@ import json
 import random
 
 from kytos.core.common import GenericEntity
+from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.interface import TAGType
 
 
@@ -134,7 +135,7 @@ class Link(GenericEntity):
             # Tag used successfully by both endpoints. Returning.
             return tag
 
-        return False
+        raise KytosNoTagAvailableError(self)
 
     def make_tag_available(self, tag):
         """Add a specific tag in available_tags."""


### PR DESCRIPTION
Instead of returning False, now the method to get an available
tag in a link raises an exception when no tag is found. Also, a
custom exception was created for that.