### PR TITLE
Return the original HTTP error code when a NApp is not found in the NApp server

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -424,10 +424,13 @@ class APIServer:
         napp = "{}/{}".format(username, napp_name)
 
         # Try to install and enable the napp
-        if not self.napps_manager.install(napp, enable=True):
-            # If it is not installed an admin user must check the log file
-            return '{"response": "error"}', \
-                   HTTPStatus.INTERNAL_SERVER_ERROR.value
+        try:
+            if not self.napps_manager.install(napp, enable=True):
+                # If it is not installed an admin user must check the log file
+                return '{"response": "error"}', \
+                       HTTPStatus.INTERNAL_SERVER_ERROR.value
+        except HTTPError as exception:
+            return '{"response": "error"}', exception.code
 
         return '{"response": "installed"}', HTTPStatus.OK.value
 


### PR DESCRIPTION
Server was returning INTERNAL_SERVER_ERROR code when a NApp was not found in the NApp server. The use of a generic code was letting kytos-utils try to enable a NApp even if it was not found in the NApp server. Besides that, this modification treats an exception raised by the kytos controller. 