### PR TITLE
Method to handle HTTPExceptions

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -15,6 +15,7 @@ from urllib.request import urlopen, urlretrieve
 from flask import Flask, jsonify, request, send_file
 from flask_cors import CORS
 from flask_socketio import SocketIO, join_room, leave_room
+from werkzeug.exceptions import HTTPException
 
 
 class APIServer:
@@ -60,6 +61,22 @@ class APIServer:
 
         # Update web-ui if necessary
         self.update_web_ui(force=False)
+
+        @self.app.errorhandler(HTTPException)
+        def handle_exception(e):
+            # pylint: disable=unused-variable, invalid-name
+            """Return a json for HTTP errors
+
+            This handler allows NApps to return HTTP error messages
+            by raising a HTTPException. When raising the Exception,
+            create it with a description.
+            """
+            response = jsonify({
+                'code': e.code,
+                'name': e.name,
+                'description': e.description
+            })
+            return response, e.code
 
     def _enable_websocket_rooms(self):
         socket = self.server

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -63,7 +63,7 @@ class APIServer:
         self.update_web_ui(force=False)
 
         @self.app.errorhandler(HTTPException)
-        def handle_exception(e):
+        def handle_exception(exception):
             # pylint: disable=unused-variable, invalid-name
             """Return a json for HTTP errors
 
@@ -72,11 +72,11 @@ class APIServer:
             create it with a description.
             """
             response = jsonify({
-                'code': e.code,
-                'name': e.name,
-                'description': e.description
+                'code': exception.code,
+                'name': exception.name,
+                'description': exception.description
             })
-            return response, e.code
+            return response, exception.code
 
     def _enable_websocket_rooms(self):
         socket = self.server


### PR DESCRIPTION
New method to handle HTTPException now return a JSON with
error code, name and description. Now NApps can simple raise a
HTTPException setting a description to return in case of error.
Fix #1086.