### PR TITLE
Fix for issue # 529 - daemon value being ignored

### DIFF
--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -27,7 +27,6 @@ from importlib import import_module
 from importlib import reload as reload_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-
 from kytos.core.api_server import APIServer
 # from kytos.core.tcp_server import KytosRequestHandler, KytosServer
 from kytos.core.atcp_server import KytosServer, KytosServerProtocol
@@ -130,17 +129,25 @@ class Controller:
         #: from napps.<username>.<napp_name> import ?....
         sys.path.append(os.path.join(self.options.napps, os.pardir))
         # Configure to log uncaught exceptions to errlog file
+        # pylint: disable=logging-format-interpolation
         logging.basicConfig(filename='kytos/kytos/core/errlog.log',
                             format='%(asctime)s:%(pathname)'
                             's:%(levelname)s:%(message)s')
         sys.excepthook = self.exhandler
 
     def exhandler(self, exctype, value, tb):
+        """Define exception hook hanndler
+        
+        Args:
+            exctype: exception type
+            value: value of exception
+            tb: traceback
+        """
         # logs uncaught exceptions into the console and errlog.log
-        traceback.print_exception(exctype, value, tb)
-        print(tb)
+        traceback.print_exception(exctype, value, traceback)
+        print(traceback)
         print('Uncaught Exception: {0}'.format(str(value)))
-        logging.exception('Uncaught Exception: {0}'.format(str(value)))
+        self.logging.exception('Uncaught Exception: {0}'.format(str(value)))
 
     def enable_logs(self):
         """Register kytos log and enable the logs."""

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -135,7 +135,7 @@ class Controller:
                             's:%(levelname)s:%(message)s')
         sys.excepthook = self.exhandler
 
-    def exhandler(self, exctype, value, traceback):
+    def exhandler(self, exctype, value, tb):
         """Define exception hook hanndler
         
         Args:
@@ -144,8 +144,8 @@ class Controller:
             tb: traceback
         """
         # logs uncaught exceptions into the console and errlog.log
-        traceback.print_exception(exctype, value, traceback)
-        print(traceback)
+        traceback.print_exception(exctype, value, tb)
+        print(tb)
         print('Uncaught Exception: {0}'.format(str(value)))
         logging.exception('Uncaught Exception: {0}'.format(str(value)))
 

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -21,6 +21,7 @@ import os
 import re
 import sys
 import threading
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
 from importlib import reload as reload_module
@@ -128,6 +129,18 @@ class Controller:
         #: Now you can access the enabled napps with:
         #: from napps.<username>.<napp_name> import ?....
         sys.path.append(os.path.join(self.options.napps, os.pardir))
+        # Configure to log uncaught exceptions to errlog file
+        logging.basicConfig(filename='kytos/kytos/core/errlog.log',
+                            format='%(asctime)s:%(pathname)'
+                            's:%(levelname)s:%(message)s')
+        sys.excepthook = self.exhandler
+
+    def exhandler(self, exctype, value, tb):
+        # logs uncaught exceptions into the console and errlog.log
+        traceback.print_exception(exctype, value, tb)
+        print(tb)
+        print('Uncaught Exception: {0}'.format(str(value)))
+        logging.exception('Uncaught Exception: {0}'.format(str(value)))
 
     def enable_logs(self):
         """Register kytos log and enable the logs."""

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -135,9 +135,9 @@ class Controller:
                             's:%(levelname)s:%(message)s')
         sys.excepthook = self.exhandler
 
+    # pylint: disable=invalid-name
     def exhandler(self, exctype, value, tb):
         """Define exception hook hanndler
-        
         Args:
             exctype: exception type
             value: value of exception

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -135,7 +135,7 @@ class Controller:
                             's:%(levelname)s:%(message)s')
         sys.excepthook = self.exhandler
 
-    def exhandler(self, exctype, value, tb):
+    def exhandler(self, exctype, value, traceback):
         """Define exception hook hanndler
         
         Args:
@@ -147,7 +147,7 @@ class Controller:
         traceback.print_exception(exctype, value, traceback)
         print(traceback)
         print('Uncaught Exception: {0}'.format(str(value)))
-        self.logging.exception('Uncaught Exception: {0}'.format(str(value)))
+        logging.exception('Uncaught Exception: {0}'.format(str(value)))
 
     def enable_logs(self):
         """Register kytos log and enable the logs."""

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -129,11 +129,6 @@ class Controller:
         #: Now you can access the enabled napps with:
         #: from napps.<username>.<napp_name> import ?....
         sys.path.append(os.path.join(self.options.napps, os.pardir))
-        # Configure to log uncaught exceptions to errlog file
-        # pylint: disable=logging-format-interpolation
-        logging.basicConfig(filename='kytos/kytos/core/errlog.log',
-                            format='%(asctime)s:%(pathname)'
-                            's:%(levelname)s:%(message)s')
         sys.excepthook = self.exhandler
 
     # pylint: disable=invalid-name,no-self-use
@@ -147,6 +142,11 @@ class Controller:
         # logs uncaught exceptions into the console and errlog.log
         traceback.print_exception(exctype, value, tb)
         print(tb)
+        # Configure to log uncaught exceptions to errlog file
+        # pylint: disable=logging-format-interpolation
+        logging.basicConfig(filename='kytos/kytos/core/errlog.log',
+                            format='%(asctime)s:%(pathname)'
+                            's:%(levelname)s:%(message)s')
         print('Uncaught Exception: {0}'.format(str(value)))
         # pylint: disable=logging-format-interpolation
         logging.exception('Uncaught Exception: {0}'.format(str(value)))

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -27,6 +27,7 @@ from importlib import import_module
 from importlib import reload as reload_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+
 from kytos.core.api_server import APIServer
 # from kytos.core.tcp_server import KytosRequestHandler, KytosServer
 from kytos.core.atcp_server import KytosServer, KytosServerProtocol
@@ -135,7 +136,7 @@ class Controller:
                             's:%(levelname)s:%(message)s')
         sys.excepthook = self.exhandler
 
-    # pylint: disable=invalid-name
+    # pylint: disable=invalid-name,no-self-use
     def exhandler(self, exctype, value, tb):
         """Define exception hook hanndler
         Args:
@@ -147,6 +148,7 @@ class Controller:
         traceback.print_exception(exctype, value, tb)
         print(tb)
         print('Uncaught Exception: {0}'.format(str(value)))
+        # pylint: disable=logging-format-interpolation
         logging.exception('Uncaught Exception: {0}'.format(str(value)))
 
     def enable_logs(self):

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -14,6 +14,7 @@ import daemon
 from IPython.terminal.embed import InteractiveShellEmbed
 from IPython.terminal.prompts import Prompts, Token
 from traitlets.config.loader import Config
+
 from kytos.core import Controller
 from kytos.core.config import KytosConfig
 from kytos.core.metadata import __version__

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -2,20 +2,21 @@
 """Start Kytos SDN Platform core."""
 import asyncio
 import functools
+import logging
 import os
 import signal
-import logging
 import sys
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
 import daemon
 from IPython.terminal.embed import InteractiveShellEmbed
 from IPython.terminal.prompts import Prompts, Token
-from traitlets.config.loader import Config
 from kytos.core import Controller
 from kytos.core.config import KytosConfig
 from kytos.core.metadata import __version__
+from traitlets.config.loader import Config
 
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -113,7 +113,8 @@ def main():
             async_main(config)
 
 
-def exhandler(exctype, value, traceback):
+# pylint: disable=invalid-name
+def exhandler(exctype, value, tb):
     """Define exception hook hanndler
         Args:
             exctype: exception type

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -115,7 +115,6 @@ def main():
 
 def exhandler(exctype, value, traceback):
     """Define exception hook hanndler
-        
         Args:
             exctype: exception type
             value: value of exception
@@ -123,8 +122,8 @@ def exhandler(exctype, value, traceback):
     """
     #
     # logs uncaught exceptions into the console and errlog.log
-    traceback.print_exception(exctype, value, traceback)
-    print(traceback)
+    traceback.print_exception(exctype, value, tb)
+    print(tb)
     # pylint: disable=logging-format-interpolation
     logging.basicConfig(filename='kytos/kytos/core/errlog.log',
                         format='%(asctime)s:%(pathname)s:'

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -109,7 +109,7 @@ def main():
     sys.excepthook = exhandler
 
     if config.daemon:
-        if (config.foreground):
+        if config.foreground:
             async_main(config)
         else:
             with daemon.DaemonContext():

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -116,7 +116,7 @@ def main():
                 async_main(config)
     else:
         config.foreground = True
-        async_main(config))
+        async_main(config)
 
 
 # pylint: disable=invalid-name

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -108,11 +108,15 @@ def main():
     # Configure to log uncaught exceptions to errlog file
     sys.excepthook = exhandler
 
-    if config.foreground:
-        async_main(config)
-    else:
-        with daemon.DaemonContext():
+    if config.daemon:
+        if (config.foreground):
             async_main(config)
+        else:
+            with daemon.DaemonContext():
+                async_main(config)
+    else:
+        config.foreground = True
+        async_main(config))
 
 
 # pylint: disable=invalid-name

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -113,10 +113,19 @@ def main():
             async_main(config)
 
 
-def exhandler(exctype, value, tb):
+def exhandler(exctype, value, traceback):
+    """Define exception hook hanndler
+        
+        Args:
+            exctype: exception type
+            value: value of exception
+            tb: traceback
+    """
+    #
     # logs uncaught exceptions into the console and errlog.log
-    traceback.print_exception(exctype, value, tb)
-    print(tb)
+    traceback.print_exception(exctype, value, traceback)
+    print(traceback)
+    # pylint: disable=logging-format-interpolation
     logging.basicConfig(filename='kytos/kytos/core/errlog.log',
                         format='%(asctime)s:%(pathname)s:'
                         '%(levelname)s:%(message)s')

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -13,10 +13,10 @@ from pathlib import Path
 import daemon
 from IPython.terminal.embed import InteractiveShellEmbed
 from IPython.terminal.prompts import Prompts, Token
+from traitlets.config.loader import Config
 from kytos.core import Controller
 from kytos.core.config import KytosConfig
 from kytos.core.metadata import __version__
-from traitlets.config.loader import Config
 
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -15,7 +15,7 @@ pidfile = {{ prefix }}/var/run/kytos/kytosd.pid
 # mode. On daemon mode, the process will detach from terminal when starts,
 # running in background. When running on 'interactive' mode, you will receive a
 # console right after the controller starts. Default is 'interactive' mode.
-daemon = False
+daemon = True
 
 # Run the controller in debug mode or not. Default is False.
 debug = False


### PR DESCRIPTION
The Capstone 1 team at FIU attempted to solve issue #529 . We did this buy modifying the if statement in the` main()` in kytosd.py to first check for config.daemon, in which its value is reflected from kytos.conf. After checking for daemon, we then check for config.foreground in case the user wants to run kytosd in foreground via -f argument. This alllows the daemon value in kytos.conf to no longer be ignored.

After this fix, we changed the default daemon value in kytos.conf.template to `True`, so when the user runs kytosd for the first time, when the kytos.conf file is generated, the default daemon value is True.