### PR TITLE
Update controller mock method to accept loop parameter

### DIFF
--- a/kytos/lib/helpers.py
+++ b/kytos/lib/helpers.py
@@ -11,10 +11,10 @@ from kytos.core.link import Link
 from kytos.core.switch import Switch
 
 
-def get_controller_mock():
+def get_controller_mock(loop=None):
     """Return a controller mock."""
     options = KytosConfig().options['daemon']
-    controller = Controller(options)
+    controller = Controller(options, loop=loop)
     controller.log = Mock()
     return controller
 


### PR DESCRIPTION
The method get_controller_mock from  kytos helpers lib was creating only controllers with the default loop parameter. This commit enable a loop parameter on the method.

Fix #1091