### PR TITLE
Change API server status HTTP code to 200

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -138,7 +138,7 @@ class APIServer:
     @staticmethod
     def status_api():
         """Display kytos status using the route ``/kytos/status/``."""
-        return '{"response": "running"}', HTTPStatus.CREATED.value
+        return '{"response": "running"}', HTTPStatus.OK.value
 
     def stop_api_server(self):
         """Send a shutdown request to stop Api Server."""


### PR DESCRIPTION
Today, when Kytos REST API is used to get API Server status, you get return code 201 instead of 200. This commit solves this problem, changing the HTTP code.

Fix #1081