### PR TITLE
Fix #529 - daemon value being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ kytos/web-ui/index.html
 # ignore templates
 etc/kytos/kytos.conf
 etc/kytos/logging.ini
+
+# ignore Visual Studio folders
+*.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,3 @@ kytos/web-ui/index.html
 # ignore templates
 etc/kytos/kytos.conf
 etc/kytos/logging.ini
-
-# ignore Visual Studio folders
-*.vs/

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -102,15 +102,11 @@ def main():
 
     config = KytosConfig().options['daemon']
 
-    if config.daemon:
-        if config.foreground:
-            async_main(config)
-        else:
-            with daemon.DaemonContext():
-                async_main(config)
-    else:
-        config.foreground = True
+    if config.foreground or not config.daemon:
         async_main(config)
+    else:
+        with daemon.DaemonContext():
+            async_main(config)
 
 
 def async_main(config):

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -102,11 +102,15 @@ def main():
 
     config = KytosConfig().options['daemon']
 
-    if config.foreground:
-        async_main(config)
-    else:
-        with daemon.DaemonContext():
+    if config.daemon:
+        if config.foreground:
             async_main(config)
+        else:
+            with daemon.DaemonContext():
+                async_main(config)
+    else:
+        config.foreground = True
+        async_main(config)
 
 
 def async_main(config):

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -15,7 +15,7 @@ pidfile = {{ prefix }}/var/run/kytos/kytosd.pid
 # mode. On daemon mode, the process will detach from terminal when starts,
 # running in background. When running on 'interactive' mode, you will receive a
 # console right after the controller starts. Default is 'daemon' mode.
-# daemon = True
+daemon = True
 
 # Run the controller in debug mode or not. Default is False.
 debug = False

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -14,7 +14,7 @@ pidfile = {{ prefix }}/var/run/kytos/kytosd.pid
 # This controller can be started in two modes: 'daemon' mode or 'interactive'
 # mode. On daemon mode, the process will detach from terminal when starts,
 # running in background. When running on 'interactive' mode, you will receive a
-# console right after the controller starts. Default is 'interactive' mode.
+# console right after the controller starts. Default is 'daemon' mode.
 daemon = True
 
 # Run the controller in debug mode or not. Default is False.

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -15,7 +15,7 @@ pidfile = {{ prefix }}/var/run/kytos/kytosd.pid
 # mode. On daemon mode, the process will detach from terminal when starts,
 # running in background. When running on 'interactive' mode, you will receive a
 # console right after the controller starts. Default is 'interactive' mode.
-daemon = False
+daemon = True
 
 # Run the controller in debug mode or not. Default is False.
 debug = False

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -15,7 +15,7 @@ pidfile = {{ prefix }}/var/run/kytos/kytosd.pid
 # mode. On daemon mode, the process will detach from terminal when starts,
 # running in background. When running on 'interactive' mode, you will receive a
 # console right after the controller starts. Default is 'daemon' mode.
-daemon = True
+# daemon = True
 
 # Run the controller in debug mode or not. Default is False.
 debug = False


### PR DESCRIPTION
The Capstone 1 team at FIU attempted to solve issue #529 . We did this buy modifying the if statement in the` main()` in kytosd.py to first check for config.daemon, in which its value is reflected from kytos.conf. After checking for daemon, we then check for config.foreground in case the user wants to run kytosd in foreground via -f argument. This alllows the daemon value in kytos.conf to no longer be ignored.

After this fix, we changed the default daemon value in kytos.conf.template to `True`, so when the user runs kytosd for the first time, when the kytos.conf file is generated, the default daemon value is True.

NOTE: During our end of semester Sprint Review meeting, we decided to close all our previous pull requests and make new ones that are less messy and more appropriate, as recommended and guided with Humberto's advice. We apologize for any inconvenience.