### PR TITLE
Ignore .vs folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ kytos/web-ui/index.html
 # ignore templates
 etc/kytos/kytos.conf
 etc/kytos/logging.ini
+
+# ignore Visual Studio folders
+*.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,5 @@ kytos/web-ui/index.html
 etc/kytos/kytos.conf
 etc/kytos/logging.ini
 
-# ignore Visual Studio folders
-*.vs/
+# Visual Studio
+.vs/


### PR DESCRIPTION
As the Capstone 1 team at FIU were working on issue # 960, we didn't notice that Visual Studio makes a .vs folder containing information related to editing the project in the IDE. Humberto caught that and mentioned it to us, and suggest that we could make a pull request adding to .gitignore to ignore the .vs folder so all files generated by the IDE are ignored.