### PR TITLE
Add instruction for opening issues with traffic files in Dev Guide

### DIFF
--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -116,9 +116,8 @@ possible:
 - **Error output** or logs pasted in your issue or in a
   `Gist <http://gist.github.com/>`__. When pasting them in the issue, wrap it
   with three backticks: **\`\`\`** so it renders nicely, like ``this``;
-- **Traffic files** - if your issue is on the network, attach as many
-  traffic files as possible (i.e.: .pcap), if they don't contain sensitive
-  information;
+- **Traffic files** - if your issue is related to network traffic, attach as many traffic files as
+ possible (i.e.: .pcap), as long as they don't contain sensitive information;
 - **Steps to reproduce** - please inform all the steps to reproduce the error;
 - **Motivation or use case** - explain why this is a bug for you;
 - **System details** like what library or operating system you’re
@@ -235,4 +234,3 @@ must be signed. It's a quick process, we promise!
 .. _GitHub repository: https://github.com/kytos/
 .. _forking workflow: https://www.atlassian.com/git/tutorials/comparing-workflows#forking-workflow
 .. _Google-style docstrings: https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments
-

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -116,8 +116,9 @@ possible:
 - **Error output** or logs pasted in your issue or in a
   `Gist <http://gist.github.com/>`__. When pasting them in the issue, wrap it
   with three backticks: **\`\`\`** so it renders nicely, like ``this``;
-- **Traffic files** - if your issue is related to network traffic, attach as many traffic files as
- possible (i.e.: .pcap), as long as they don't contain sensitive information;
+- **Traffic files** - if your issue is related to network traffic, attach as
+  many traffic files as possible (i.e.: .pcap), as long as they don't contain
+  sensitive information;
 - **Steps to reproduce** - please inform all the steps to reproduce the error;
 - **Motivation or use case** - explain why this is a bug for you;
 - **System details** like what library or operating system you’re

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -116,6 +116,9 @@ possible:
 - **Error output** or logs pasted in your issue or in a
   `Gist <http://gist.github.com/>`__. When pasting them in the issue, wrap it
   with three backticks: **\`\`\`** so it renders nicely, like ``this``;
+- **Traffic files** - if your issue is on the network, attach as many
+  traffic files as possible (i.e.: .pcap), if they don't contain sensitive
+  information;
 - **Steps to reproduce** - please inform all the steps to reproduce the error;
 - **Motivation or use case** - explain why this is a bug for you;
 - **System details** like what library or operating system you’re


### PR DESCRIPTION
Update "Submitting an Issue" section on DevGuide, adding a bullet to instruct users to attach traffic files, if they do not contain sensitive information.

Fix #1108