### PR TITLE
Remove outdated links and update date

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -51,13 +51,13 @@
          <div id="social-kytos">
            <div class="row docs-social">
              <ul class="icon col-md-12">
-               <li class="col-md-4 center">
+               <li class="col-md-6 center">
                   <i class="fa fa-comments"></i> <a href="irc://irc.freenode.net/#kytos-dev">Kytos @ freenode</a>
                </li>
-               <li class="col-md-4 center">
+               <!-- <li class="col-md-4 center">
                   <i class="fa fa-envelope"></i> <a href="https://lists.kytos.io/">lists.kytos.io</a>
-               </li>
-               <li class="col-md-4 center">
+               </li> -->
+               <li class="col-md-6 center">
                   <i class="fa icon-slack"></i> <a href="https://join.slack.com/t/kytos/shared_invite/enQtMjk0MTM0NjQwOTE1LTkzODE2YTQ3NTQ0MGRlYzcyNTZjYjQ4Yjc2NmI5NWZmNmMxNjNiOTVkOTE0YTQwN2Q2NjZjNDkwODM5OWRjNGY">Kytos @ Channel</a>
                </li>
              </ul>
@@ -66,7 +66,7 @@
                <div class="text-center">
                  <hr>
                  <p>
-                  © 2016 - 2018  Kytos is an Open Source software under MIT license.<br>
+                  © 2016 - 2020  Kytos is an Open Source software under MIT license.<br>
                  </p>
                </div>
              </div>


### PR DESCRIPTION
Today, some links and project years on the documentation are outdated, this commit resolves that.
