### PR TITLE
Update six version (1.14 -> 1.15) 

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -45,7 +45,7 @@ pytest==5.4.1             # via -r requirements/dev.in
 pytz==2019.3              # via babel
 pyyaml==5.3.1             # via sphinx-autobuild
 requests==2.23.0          # via sphinx
-six==1.14.0               # via astroid, livereload, packaging, pip-tools, tox, virtualenv
+six==1.15.0               # via astroid, livereload, packaging, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autobuild==0.7.1   # via kytos-sphinx-theme
 sphinx==2.0.1             # via kytos-sphinx-theme

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -32,7 +32,7 @@ python-daemon==2.2.4      # via -r requirements/run.in
 python-engineio==3.12.1   # via python-socketio
 python-openflow==2020.1rc1  # via -r requirements/run.in
 python-socketio==4.5.1    # via flask-socketio
-six==1.14.0               # via flask-cors, python-socketio, traitlets
+six==1.15.0               # via flask-cors, python-socketio, traitlets
 traitlets==4.3.3          # via ipython
 watchdog==0.10.2          # via -r requirements/run.in
 wcwidth==0.1.9            # via prompt-toolkit


### PR DESCRIPTION
This update fixes the error in 'Build packages' step (fix #1111) involving twine kytos dependencies.