### PR TITLE
Add Blueprints section to the "How to Contribute" guide

### DIFF
--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -19,7 +19,7 @@ Here are the guidelines we follow for different ways of contributing:
 - `Want a Feature?`_
 - `Want a Doc Fix?`_
 - `Submission Guidelines`_
-- `Blueprint`_
+- `Blueprints`_
 - `Coding Style`_
 - `Signing the CLA`_
 
@@ -50,7 +50,7 @@ it is:
 
 - **Major Changes** that you wish to contribute to the project should be
   discussed first in our `Slack channel`_, so that we can better coordinate our 
-  efforts, prevent work duplication, and help you to craft the changes so they 
+  efforts, prevent work duplication, and help you craft the changes so they 
   are successfully integrated into the project.
 
 - **Small Changes** can be crafted and submitted to the |repo| as Pull Requests.

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -19,6 +19,7 @@ Here are the guidelines we follow for different ways of contributing:
 - `Want a Feature?`_
 - `Want a Doc Fix?`_
 - `Submission Guidelines`_
+- `Blueprint`_
 - `Coding Style`_
 - `Signing the CLA`_
 
@@ -211,13 +212,15 @@ Code contribution steps review
 Blueprint
 ---------
 
-We have a type of document used to describe our architectural choices, called a
-‘blueprint’. This document is used to specify the details of any process, 
-resources and anything else that is desirable to be implemented in the Kytos 
-Project and cannot be reduced to a Github problem or a meeting to be outlined. 
-This document records all the major architectural decisions made in the kytos 
-project, this document is developed for our current developers and mainly for 
-future developers.
+We have a type of document used to describe our architectural choices, called a 
+‘blueprint’. This document records all the main architectural decisions made in 
+the kytos project, this document is developed for our current developers and 
+mainly for our future developers. This document is used to specify the details 
+of any process, resource, and anything else that is desirable to be implemented, 
+resulting in a major architectural change. You can check out our blueprints to 
+learn more about our architectural choices in the `blueprint section`_. 
+Remember that this document is not just for you, but mainly for other 
+developers. 
 
 Coding style
 ------------
@@ -246,3 +249,4 @@ must be signed. It's a quick process, we promise!
 .. _Slack channel: https://join.slack.com/t/kytos/shared_
   invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTNiNDNiY2JmNGFlMGQxY2I5Y2IxY
   jBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM
+.. _blueprint section: https://github.com/kytos/kytos/tree/master/docs/blueprints

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -212,15 +212,14 @@ Code contribution steps review
 Blueprint
 ---------
 
-We have a type of document used to describe our architectural choices, called a 
-‘blueprint’. This document records all the main architectural decisions made in 
-the kytos project, this document is developed for our current developers and 
-mainly for our future developers. This document is used to specify the details 
-of any process, resource, and anything else that is desirable to be implemented, 
-resulting in a major architectural change. You can check out our blueprints to 
-learn more about our architectural choices in the `blueprint section`_. 
-Remember that this document is not just for you, but mainly for other 
-developers. 
+We have a type of document used to describe our architectural choices, called 
+‘blueprint’. This document is developed for our developers and records all the
+main architectural decisions made in the kytos project. Blueprints are used to
+specify the details of any process, resource, and anything else that is
+desirable to be implemented, resulting in a major architectural change. You can
+check out our blueprints to learn more about our architectural choices in the
+`blueprint section`_. Remember that this document is not just for you, but
+mainly for other developers.
 
 Coding style
 ------------

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -7,9 +7,7 @@ feedback is important for us to fix bugs, add new features and
 make it easier to create and share Network Applications.
 
 To give us your feedback, check the most appropriate instructions in the next
-section. You can also contact us directly on the `Slack channel <https://join.
-slack.com/t/kytos/shared_invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTN
-iNDNiY2JmNGFlMGQxY2I5Y2IxYjBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM>`_.
+section. You can also contact us directly on the `Slack channel`_.
 
 Contributing Guidelines
 -----------------------
@@ -28,9 +26,7 @@ Got a Question or Problem?
 --------------------------
 
 If you have questions about how to use any component of the Kytos project,
-direct them to our `Slack channel <https://join.slack.com/t/kytos/shared_
-invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTNiNDNiY2JmNGFlMGQxY2I5Y2IxY
-jBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM>`_.
+direct them to our `Slack channel`_.
 
 .. _contributing-issue:
 
@@ -52,9 +48,7 @@ If you would like to implement a new feature, then consider what kind of change
 it is:
 
 - **Major Changes** that you wish to contribute to the project should be
-  discussed first in our `Slack channel <https://join.slack.com/t/kytos/shared_
-  invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTNiNDNiY2JmNGFlMGQxY2I5Y2IxY
-  jBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM>`_, so that we can better coordinate our 
+  discussed first in our `Slack channel`_, so that we can better coordinate our 
   efforts, prevent work duplication, and help you to craft the changes so they 
   are successfully integrated into the project.
 
@@ -249,3 +243,6 @@ must be signed. It's a quick process, we promise!
 .. _GitHub repository: https://github.com/kytos/
 .. _forking workflow: https://www.atlassian.com/git/tutorials/comparing-workflows#forking-workflow
 .. _Google-style docstrings: https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments
+.. _Slack channel: https://join.slack.com/t/kytos/shared_
+  invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTNiNDNiY2JmNGFlMGQxY2I5Y2IxY
+  jBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -213,13 +213,16 @@ Blueprints
 ----------
 
 We have a type of document used to describe our architectural choices, called 
-‘blueprint’. This document is developed for our developers and records all the
-main architectural decisions made in the kytos project. Blueprints are used to
-specify the details of any process, resource, and anything else that is
-desirable to be implemented, resulting in a major architectural change. You can
-check out our blueprints to learn more about our architectural choices in the
-`blueprints section`_. Remember that this document is not just for you, but
-mainly for other developers.
+‘blueprint’. This document is written for our developers and users and records 
+all the main architectural decision proposals that were accepted or not in the 
+kytos project. Blueprints are used to specify the details of any process, 
+resource, and anything else that is desirable to be implemented, resulting in a 
+major architectural change. You can check out our blueprints to learn more 
+about our architectural choices in the `blueprints section`_. Anyone can make 
+enhancement proposals writing `blueprints`, but first is highly recommended 
+with you know about our past choices by reading in the `blueprints section`_. 
+Remember that this document is not just for you, but mainly for other 
+developers. 
 
 Coding style
 ------------

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -7,8 +7,9 @@ feedback is important for us to fix bugs, add new features and
 make it easier to create and share Network Applications.
 
 To give us your feedback, check the most appropriate instructions in the next
-section. You can also contact us directly and subscribe to mailing lists as
-described in the :doc:`/home/get_help` section.
+section. You can also contact us directly on the `Slack channel <https://join.
+slack.com/t/kytos/shared_invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTN
+iNDNiY2JmNGFlMGQxY2I5Y2IxYjBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM>`_.
 
 Contributing Guidelines
 -----------------------
@@ -27,8 +28,9 @@ Got a Question or Problem?
 --------------------------
 
 If you have questions about how to use any component of the Kytos project,
-direct them to our dev mailing list. We are also available on IRC. Check the
-details in the :doc:`/home/get_help` section.
+direct them to our `Slack channel <https://join.slack.com/t/kytos/shared_
+invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTNiNDNiY2JmNGFlMGQxY2I5Y2IxY
+jBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM>`_.
 
 .. _contributing-issue:
 
@@ -50,10 +52,11 @@ If you would like to implement a new feature, then consider what kind of change
 it is:
 
 - **Major Changes** that you wish to contribute to the project should be
-  discussed first in our dev mailing list or IRC (see: :doc:`/home/get_help`
-  section), so that we can better coordinate our efforts, prevent work
-  duplication, and help you to craft the changes so they are successfully
-  integrated into the project.
+  discussed first in our `Slack channel <https://join.slack.com/t/kytos/shared_
+  invite/enQtMjk0MTM0NjQwOTE1LTE2N2UyNWE2YjNjNzY0MTNiNDNiY2JmNGFlMGQxY2I5Y2IxY
+  jBhMTkwZjZjNDQ4Zjk3ZjExZGFjNGYzMzRjMDM>`_, so that we can better coordinate our 
+  efforts, prevent work duplication, and help you to craft the changes so they 
+  are successfully integrated into the project.
 
 - **Small Changes** can be crafted and submitted to the |repo| as Pull Requests.
 
@@ -210,6 +213,17 @@ Code contribution steps review
 #.  Push to your origin repository
 #.  Create a new PR in GitHub
 #.  Respond to any code review feedback
+
+Blueprint
+---------
+
+We have a type of document used to describe our architectural choices, called a
+‘blueprint’. This document is used to specify the details of any process, 
+resources and anything else that is desirable to be implemented in the Kytos 
+Project and cannot be reduced to a Github problem or a meeting to be outlined. 
+This document records all the major architectural decisions made in the kytos 
+project, this document is developed for our current developers and mainly for 
+future developers.
 
 Coding style
 ------------

--- a/docs/developer/how_to_contribute.rst
+++ b/docs/developer/how_to_contribute.rst
@@ -217,10 +217,9 @@ We have a type of document used to describe our architectural choices, called
 all the main architectural decision proposals that were accepted or not in the 
 kytos project. Blueprints are used to specify the details of any process, 
 resource, and anything else that is desirable to be implemented, resulting in a 
-major architectural change. You can check out our blueprints to learn more 
-about our architectural choices in the `blueprints section`_. Anyone can make 
-enhancement proposals writing `blueprints`, but first is highly recommended 
-with you know about our past choices by reading in the `blueprints section`_. 
+major architectural change. Anyone can make enhancement proposals 
+writing new `blueprints`, but first it is highly recommended that you take
+a look at our `blueprints section`_ to read about our past choices. 
 Remember that this document is not just for you, but mainly for other 
 developers. 
 


### PR DESCRIPTION
Added blueprint related section and contact links have been updated on how_contribute_guide.


Fix #1135