### PR TITLE
Fix interface tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,8 @@ class Test(TestCommand):
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
+            print('Unit tests failed. Fix the error(s) above and try again.')
+            sys.exit(-1)
 
 
 class TestCoverage(Test):
@@ -147,6 +149,8 @@ class TestCoverage(Test):
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
+            print('Coverage tests failed. Fix the errors above and try again.')
+            sys.exit(-1)
 
 
 class DocTest(SimpleCommand):

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -125,7 +125,6 @@ class TestInterface(unittest.TestCase):
     def test_speed_setter(self):
         """Should return speed that was set and not features'."""
         expected_speed = 12345
-        self.iface.features = PortFeatures.OFPPF_10MB_FD
         self.iface.set_custom_speed(expected_speed)
         actual_speed = self.iface.speed
         self.assertEqual(expected_speed, actual_speed)
@@ -133,20 +132,18 @@ class TestInterface(unittest.TestCase):
     def test_speed_in_constructor(self):
         """Custom speed should override features'."""
         expected_speed = 6789
-        iface = self._get_v0x04_iface(speed=expected_speed,
-                                      features=PortFeatures.OFPPF_10MB_FD)
-        actual_speed = iface.speed
-        self.assertEqual(expected_speed, actual_speed)
+        iface = self._get_v0x04_iface(speed=expected_speed)
+        self.assertEqual(expected_speed, iface.speed)
 
-    def test_remove_custom_speed(self):
-        """Should return features' speed again when custom's becomes None."""
+    def test_speed_removing_features(self):
+        """Should return custom's speed again when features' becomes None."""
         custom_speed = 101112
         of_speed = 10 * 10**6 / 8
         iface = self._get_v0x04_iface(speed=custom_speed,
                                       features=PortFeatures.OFPPF_10MB_FD)
-        self.assertEqual(custom_speed, iface.speed)
-        iface.set_custom_speed(None)
         self.assertEqual(of_speed, iface.speed)
+        iface.features = None
+        self.assertEqual(custom_speed, iface.speed)
 
     def test_interface_available_tags(self):
         """Test available_tags on Interface class."""

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -136,7 +136,7 @@ class TestInterface(unittest.TestCase):
         self.assertEqual(expected_speed, iface.speed)
 
     def test_speed_removing_features(self):
-        """Should return custom's speed again when features' becomes None."""
+        """Should return custom speed again when features becomes None."""
         custom_speed = 101112
         of_speed = 10 * 10**6 / 8
         iface = self._get_v0x04_iface(speed=custom_speed,


### PR DESCRIPTION
Today, some interface tests are broken, due to a modification on speed order checks. This PR fixes these tests.