### PR TITLE
Add authentication to REST methods based on configuration option

### DIFF
--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -128,7 +128,7 @@ class KytosConfig():
                     'enable_entities_by_default': False,
                     'napps_pre_installed': '[]',
                     'authenticate_urls': '[]',
-                    'vlan_pool': '{}',
+                    'vlan_pool': {},
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -126,8 +126,8 @@ class KytosConfig():
                     'foreground': False,
                     'protocol_name': '',
                     'enable_entities_by_default': False,
-                    'napps_pre_installed': '[]',
-                    'authenticate_urls': '[]',
+                    'napps_pre_installed': [],
+                    'authenticate_urls': [],
                     'vlan_pool': {},
                     'debug': False}
 
@@ -149,9 +149,6 @@ class KytosConfig():
         self.parser.set_defaults(**defaults)
 
         self.options['daemon'] = self._parse_options(argv)
-        authenticate_urls = self.options['daemon'].authenticate_urls
-        self.options['daemon'].authenticate_urls = json.loads(
-            authenticate_urls)
 
     def _parse_options(self, argv):
         """Create a Namespace using the given argv.
@@ -176,12 +173,15 @@ class KytosConfig():
         result = options.enable_entities_by_default in ['True', True]
         options.enable_entities_by_default = result
 
-        if isinstance(options.napps_pre_installed, str):
-            napps = options.napps_pre_installed
-            options.napps_pre_installed = json.loads(napps)
+        def _parse_json(value):
+            """Parse JSON lists and dicts from the config file."""
+            if isinstance(value, str):
+                return json.loads(value)
+            return value
 
-        if isinstance(options.vlan_pool, str):
-            options.vlan_pool = json.loads(options.vlan_pool)
+        options.napps_pre_installed = _parse_json(options.napps_pre_installed)
+        options.vlan_pool = _parse_json(options.vlan_pool)
+        options.authenticate_urls = _parse_json(options.authenticate_urls)
 
         return options
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -126,8 +126,9 @@ class KytosConfig():
                     'foreground': False,
                     'protocol_name': '',
                     'enable_entities_by_default': False,
-                    'napps_pre_installed': [],
-                    'vlan_pool': {},
+                    'napps_pre_installed': '[]',
+                    'authenticate_urls': '[]',
+                    'vlan_pool': '{}',
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()
@@ -148,6 +149,9 @@ class KytosConfig():
         self.parser.set_defaults(**defaults)
 
         self.options['daemon'] = self._parse_options(argv)
+        authenticate_urls = self.options['daemon'].authenticate_urls
+        self.options['daemon'].authenticate_urls = json.loads(
+            authenticate_urls)
 
     def _parse_options(self, argv):
         """Create a Namespace using the given argv.

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -783,6 +783,7 @@ class Controller:
         self.napps[(username, napp_name)] = napp
 
         napp.start()
+        self.api_server.authenticate_endpoints(napp)
         self.api_server.register_napp_endpoints(napp)
 
         # pylint: disable=protected-access

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -2,9 +2,7 @@
 from datetime import datetime, timezone
 from threading import Thread
 
-from kytos.core.napps import rest
-
-__all__ = ['listen_to', 'now', 'rest', 'run_on_thread', 'get_time']
+__all__ = ['listen_to', 'now', 'run_on_thread', 'get_time']
 
 
 # APP_MSG = "[App %s] %s | ID: %02d | R: %02d | P: %02d | F: %s"

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -69,3 +69,10 @@ vlan_pool = {}
 
 # The jwt_secret parameter is responsible for signing JSON Web Tokens.
 jwt_secret = {{ jwt_secret }}
+
+# Define URLs that will require authentication
+#
+# This must be a list of part of URLs. For example, if "kytos/mef_eline"
+# is in the list, then every URL containing "kytos/mef_eline" will match
+# it and, therefore, require authentication.
+# authenticate_urls = ["kytos/mef_eline", "kytos/pathfinder"]


### PR DESCRIPTION
Users can configure kytos to add configuration to REST methods. This PR does the following:

- remove unecessary `rest` import in `kytos.core.helpers`;
- add configuration option `authenticate_urls`;
- decorate defined methods with `authenticated` before registering in Flask.

The configuration is based on URLs, so if any URL a method is registered to matches `authenticate_urls`, the method will
enforce authentication.
An endpoint URL is considered to match `authenticate_urls` if any URL defined there is a substring of the endpoint URL.
For example, assume `authenticate_urls = ["kytos/mef_eline", "pathfinder"]`, then:
- `/api/kytos/mef_eline/1` matches;
- `/api/kytos/pathfinder` matches;
- `/api/amlight/pathfinder` matches.
- `/api/amlight/mef_eline` does NOT match;

Fixes #1136.