### PR TITLE
Create config field in Interface

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -368,6 +368,9 @@ rst_epilog = """
 .. |port_features| replace::
    :class:`~pyof.v0x01.common.phy_port.PortFeatures`
 
+.. |port_config| replace::
+   :class:`~pyof.v0x01.common.phy_port.PortConfig`
+
 .. |desc_stats| replace::
    :class:`~pyof.v0x01.controller2switch.common.DescStats`
 

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -79,10 +79,10 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
                 to what is informed by the switch. Return ``None`` if not set
                 and switch does not inform the speed.
             config(|port_config|): Port config used to indicate interface
-                behavior (administratively down, ignore reveived packets, drop
-                forwarded packets, do not send packet-in messages). In general,
-                the port config bits are set by the controller and not changed
-                by the switch.
+                behavior. In general, the port config bits are set by the
+                controller and are not changed by the switch. Options
+                are: administratively down, ignore received packets, drop
+                forwarded packets, and/or do not send packet-in messages.
         """
         self.name = name
         self.port_number = int(port_number)

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -63,7 +63,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, port_number, switch, address=None, state=None,
-                 features=None, speed=None):
+                 features=None, speed=None, config=None):
         """Assign the parameters to instance attributes.
 
         Args:
@@ -78,6 +78,11 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             speed (int, float): Interface speed in bytes per second. Defaults
                 to what is informed by the switch. Return ``None`` if not set
                 and switch does not inform the speed.
+            config(|port_config|): Port config used to indicate interface
+                behavior (administratively down, ignore reveived packets, drop
+                forwarded packets, do not send packet-in messages). In general,
+                the port config bits are set by the controller and not changed
+                by the switch.
         """
         self.name = name
         self.port_number = int(port_number)
@@ -85,6 +90,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         self.address = address
         self.state = state
         self.features = features
+        self.config = config
         self.nni = False
         self.endpoints = []
         self.stats = None


### PR DESCRIPTION
This PR creates a new 'config' field on Interface class. This field can assume one of the following values from Port or PhyPort classes:

OFPPC_PORT_DOWN: Port is administratively down;
OFPPC_NO_RECV: Drop all packets received by port;
OFPPC_NO_FWD: Drop packets forwarded to port;
OFPPC_NO_PACKET_IN: Do not send packet-in msgs for port.

Fix kytos/of_core#79