### PR TITLE
Handle URLError when it's not possible to fetch the web UI from github

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -231,8 +231,8 @@ class APIServer:
             except HTTPError:
                 return f"Uri not found {uri}."
             except URLError:
-                self.log.warning("Error accessing the %s.", uri)
-                return f"Error accessing the {uri}."
+                self.log.warning("Error accessing URL %s.", uri)
+                return f"Error accessing URL {uri}."
 
             # test downloaded zip file
             zip_ref = zipfile.ZipFile(package, 'r')

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -200,7 +200,10 @@ class APIServer:
 
     def web_ui(self):
         """Serve the index.html page for the admin-ui."""
-        return send_file(f"{self.flask_dir}/index.html")
+        index_path = f"{self.flask_dir}/index.html"
+        if os.path.exists(index_path):
+            return send_file(index_path)
+        return f"File '{index_path}' not found.", HTTPStatus.NOT_FOUND.value
 
     def update_web_ui(self, version='latest', force=True):
         """Update the static files for the Web UI.
@@ -227,6 +230,9 @@ class APIServer:
                 package = urlretrieve(uri)[0]
             except HTTPError:
                 return f"Uri not found {uri}."
+            except URLError:
+                self.log.warning("Error accessing the %s.", uri)
+                return f"Error accessing the {uri}."
 
             # test downloaded zip file
             zip_ref = zipfile.ZipFile(package, 'r')

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -113,12 +113,22 @@ class TestAPIServer(unittest.TestCase):
             self.assertEqual(response.json, expected_json)
             self.assertEqual(response.status_code, 200)
 
+    @patch('os.path')
     @patch('kytos.core.api_server.send_file')
-    def test_web_ui(self, mock_send_file):
+    def test_web_ui__success(self, mock_send_file, ospath_mock):
         """Test web_ui method."""
+        ospath_mock.exists.return_value = True
         self.api_server.web_ui()
 
         mock_send_file.assert_called_with('flask_dir/index.html')
+
+    @patch('os.path')
+    def test_web_ui__error(self, ospath_mock):
+        """Test web_ui method."""
+        ospath_mock.exists.return_value = False
+        _, error = self.api_server.web_ui()
+
+        self.assertEqual(error, 404)
 
     @patch('kytos.core.api_server.urlretrieve')
     @patch('kytos.core.api_server.urlopen')


### PR DESCRIPTION
This PR handle the exception URLError raised when is not possible fetch the web UI from GitHub. This can be caused for example when is not possible to DNS resolve github address. Fix #1117 . 