### PR TITLE
Remove the use of distutils due to incompatibility with setuptools 50.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ build: clean prepare
 	ls -l dist/
 
 clean:
-	rm -rf build/ dist/ *.egg-info/ kytos/web-ui-*
+	rm -vrf build/ dist/ *.egg-info/ kytos/web-ui-*
+	find . -name __pycache__ -type d | xargs rm -rf
+	test -d docs && make -C docs/ clean
 
 prepare:
 	pip3 install --upgrade pip setuptools wheel twine

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import re
 import sys
 from abc import abstractmethod
 # Disabling checks due to https://github.com/PyCQA/pylint/issues/73
-from distutils.command.clean import clean  # pylint: disable=E0401,E0611
 from pathlib import Path
 from subprocess import CalledProcessError, call, check_call
 
@@ -99,17 +98,14 @@ class TestCommand(Command):
             sys.exit(-1)
 
 
-class Cleaner(clean):
+class Cleaner(SimpleCommand):
     """Custom clean command to tidy up the project root."""
 
     description = 'clean build, dist, pyc and egg from package and docs'
 
     def run(self):
         """Clean build, dist, pyc and egg from package and docs."""
-        super().run()
-        call('rm -vrf ./build ./dist ./*.egg-info', shell=True)
-        call('find . -name __pycache__ -type d | xargs rm -rf', shell=True)
-        call('test -d docs && make -C docs/ clean', shell=True)
+        call('make clean', shell=True)
 
 
 class Test(TestCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ commands=
     ; Force packaging even if setup.{py,cfg} haven't changed
     rm -rf ./kytos.egg-info/
     python setup.py ci
-    # The build of documetation are being done outside of tox env, so it is 
-    # necessary clear the build after run ci command with "make clean-C docs".
+    # The build of the documentation is running outside the tox env, so it is 
+    # necessary to clear the build after running ci.
     make clean -C docs
 
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,15 @@ envlist = py36
 [testenv]
 whitelist_externals=
     rm
+    make
 
 commands=
     ; Force packaging even if setup.{py,cfg} haven't changed
     rm -rf ./kytos.egg-info/
     python setup.py ci
+    # The build of documetation are being done outside of tox env, so it is 
+    # necessary clear the build after run ci command with "make clean-C docs".
+    make clean -C docs
 
 deps=
     -rrequirements/dev.txt


### PR DESCRIPTION
This PR remove the use of distutils in setup.py once that distutils is being deprecate as we can see in PEP 632: https://www.python.org/dev/peps/pep-0632/
Another useful information is the Porting from Distutils page: https://setuptools.readthedocs.io/en/latest/distutils-legacy.html