### PR TITLE
Create KytosLinkCreationError exception

### DIFF
--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -77,6 +77,10 @@ class KytosNoTagAvailableError(Exception):
         return msg
 
 
+class KytosLinkCreationError(Exception):
+    """Exception thrown when the link has an empty endpoint."""
+
+
 # Exceptions related  to NApps
 
 

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -9,7 +9,8 @@ import json
 import random
 
 from kytos.core.common import GenericEntity
-from kytos.core.exceptions import KytosNoTagAvailableError
+from kytos.core.exceptions import (KytosLinkCreationError,
+                                   KytosNoTagAvailableError)
 from kytos.core.interface import TAGType
 
 
@@ -22,9 +23,9 @@ class Link(GenericEntity):
         Two kytos.core.interface.Interface are required as parameters.
         """
         if endpoint_a is None:
-            raise ValueError("endpoint_a cannot be None")
+            raise KytosLinkCreationError("endpoint_a cannot be None")
         if endpoint_b is None:
-            raise ValueError("endpoint_b cannot be None")
+            raise KytosLinkCreationError("endpoint_b cannot be None")
         self.endpoint_a = endpoint_a
         self.endpoint_b = endpoint_b
         super().__init__()

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -4,6 +4,7 @@ import time
 import unittest
 from unittest.mock import Mock, patch
 
+from kytos.core.exceptions import KytosLinkCreationError
 from kytos.core.interface import Interface, TAGType
 from kytos.core.link import Link
 from kytos.core.switch import Switch
@@ -74,10 +75,10 @@ class TestLink(unittest.TestCase):
 
     def test_init_with_null_endpoints(self):
         """Test initialization with None as endpoints."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KytosLinkCreationError):
             Link(self.iface1, None)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KytosLinkCreationError):
             Link(None, self.iface2)
 
     def test_link_id(self):


### PR DESCRIPTION
Today, when a Link has an empty endpoint, a generic ValueError is generated. This PR changes it, now an exception called KytosLinkCreationError is thrown when this problem occurs.

Fix kytos/topology#110