### PR TITLE
Use keys with multiple letters in mock link metadata

### DIFF
--- a/kytos/lib/helpers.py
+++ b/kytos/lib/helpers.py
@@ -36,7 +36,7 @@ def get_link_mock(endpoint_a, endpoint_b):
     link = create_autospec(Link)
     link.endpoint_a = endpoint_a
     link.endpoint_b = endpoint_b
-    link.metadata = {"A": 0}
+    link.metadata = {"A": 0, "BB": 0.0, "CCC": "test"}
     return link
 
 

--- a/tests/unit/test_lib/test_helpers.py
+++ b/tests/unit/test_lib/test_helpers.py
@@ -41,7 +41,8 @@ class TestHelpers(TestCase):
 
         self.assertEqual(link_mock.endpoint_a, endpoint_a)
         self.assertEqual(link_mock.endpoint_b, endpoint_b)
-        self.assertEqual(link_mock.metadata, {"A": 0})
+        self.assertEqual(link_mock.metadata, {"A": 0, "BB": 0.0,
+                                              "CCC": "test"})
 
     def test_switch_mock(self):
         """Test switch mock."""


### PR DESCRIPTION
Old metadata: {"A": 0} 
New metadata: {"A": 0, "BB": 0.0, "CCC": "test"}
This fixes #1162 since it causes the current iteration of test_graph to fail and thus exposes kytos/pathfinder#64:

![Screenshot from 2020-09-10 21-42-41](https://user-images.githubusercontent.com/26232289/92840117-b97c1f80-f3ae-11ea-878e-826a0f9dac9f.png)

`keys`, which is the argument of `_set_default_metadata(...)`, contains the same attribute names repeated three (3) times because it is filled with all of the metadata in the graph and the mock topology has three (3) edges, each with the same metadata.