### PR TITLE
New kytosd option to run in foreground without terminal

### DIFF
--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -56,7 +56,7 @@ class KytosConfig():
                             action='store_true',
                             help="Run in foreground (ctrl+c to stop)")
 
-        parser.add_argument('-ft', '--no_terminal',
+        parser.add_argument('-F', '--no-terminal',
                             action='store_true',
                             help="Run in foreground without terminal (ctrl+c to stop).")
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -56,6 +56,10 @@ class KytosConfig():
                             action='store_true',
                             help="Run in foreground (ctrl+c to stop)")
 
+        parser.add_argument('-ft', '--no_terminal',
+                            action='store_true',
+                            help="Run in foreground without terminal (ctrl+c to stop).")
+
         parser.add_argument('-l', '--listen',
                             action='store',
                             help="IP/Interface to be listened")
@@ -124,6 +128,7 @@ class KytosConfig():
                     'listen': '0.0.0.0',
                     'port': 6653,
                     'foreground': False,
+                    'no_terminal': False,
                     'protocol_name': '',
                     'enable_entities_by_default': False,
                     'napps_pre_installed': [],
@@ -168,6 +173,8 @@ class KytosConfig():
         options.port = int(options.port)
         options.api_port = int(options.api_port)
         options.protocol_name = str(options.protocol_name)
+        if options.no_terminal:
+            options.foreground = True
 
         result = options.enable_entities_by_default in ['True', True]
         options.enable_entities_by_default = result

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -69,8 +69,6 @@ def start_shell(controller=None):
         banner1 += f"    WEB UI........: http://{address}:{api_port}/\n"
         banner1 += f"    Kytos Version.: {__version__}"
 
-    banner1 += "\n"
-
     cfg = Config()
     cfg.TerminalInteractiveShell.autocall = 2
     cfg.TerminalInteractiveShell.show_rewritten_input = False
@@ -80,12 +78,17 @@ def start_shell(controller=None):
     # on Kytos shutdown
     cfg.HistoryAccessor.enabled = False
 
-    ipshell = InteractiveShellEmbed(config=cfg,
-                                    banner1=banner1,
-                                    exit_msg=exit_msg)
-    ipshell.prompts = KytosPrompt(ipshell)
+    if controller and controller.options.no_terminal:
+        banner1 += " \n"
+        banner1 += f"    Running Kytos without TERMINAL."
+        controller.log.info(banner1)
+    else:
+        ipshell = InteractiveShellEmbed(config=cfg,
+                                        banner1=banner1,
+                                        exit_msg=exit_msg)
+        ipshell.prompts = KytosPrompt(ipshell)
 
-    ipshell()
+        ipshell()
 
 
 # def disable_threadpool_exit():


### PR DESCRIPTION
This PR add na new option to run kytosd in foreground  without terminal.
The main use is to run kytos in foreground mode in daemon containers like docker.

Fix #1161 
