### PR TITLE
Build documentation with `python3` instead of 3.6

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 ifeq (${PYTHON}, )
-  override PYTHON = python3.6
+  override PYTHON = python3
 endif
 
 default:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -5,7 +5,7 @@ Kytos Documentation
 Requirements
 ============
 
-To install the docs requirements you must have Python 3.6 and NodeJS
+To install the docs requirements you must have Python 3 and NodeJS
 9.5.0. After that, install the requirements to build the docs using the
 command below.
 
@@ -32,4 +32,4 @@ access the browser using the address http://localhost:8000 .
 
 .. code-block:: sh
 
-  python3.6 -m http.server
+  python3 -m http.server


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change

Update documentation build to run with python3 instead the python3.6

Related: #1148  

### :page_facing_up: Release Notes

Examples:

- Drop python 3.6 version requirements from docs build;