### PR TITLE
Disable running interactive terminal by default with foreground mode

### DIFF
--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -56,6 +56,10 @@ class KytosConfig():
                             action='store_true',
                             help="Run in foreground (ctrl+c to stop)")
 
+        parser.add_argument('-i', '--interactive',
+                            action='store_true',
+                            help="Run with interactive terminal")
+
         parser.add_argument('-l', '--listen',
                             action='store',
                             help="IP/Interface to be listened")

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -145,7 +145,7 @@ def async_main(config):
 
     loop.call_soon(controller.start)
 
-    if controller.options.foreground:
+    if controller.options.interactive:
         executor = ThreadPoolExecutor(max_workers=1)
         loop.create_task(start_shell_async())
 


### PR DESCRIPTION
# Description

This pull requests removes running the interactive terminal by default when executing in foreground mode,
and instead makes the feature accessible through the `-i` or `--interactive` command line option.

This pull resolves both #1168 and #1133