### PR TITLE
Add pydocstyle to development requirements

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -65,7 +65,7 @@ class APIServer:
         @self.app.errorhandler(HTTPException)
         def handle_exception(exception):
             # pylint: disable=unused-variable, invalid-name
-            """Return a json for HTTP errors
+            """Return a json for HTTP errors.
 
             This handler allows NApps to return HTTP error messages
             by raising a HTTPException. When raising the Exception,

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,6 +2,7 @@
 -e git+git://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme
 pip-tools >= 2.0
 coverage
+pydocstyle
 pytest
 yala
 tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,6 +28,8 @@ flask-socketio==4.2.1     # via -r requirements/run.txt
 flask==1.1.2              # via -r requirements/run.txt, flask-cors, flask-socketio
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
+importlib-metadata==1.7.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 ipython-genutils==0.2.0   # via -r requirements/run.txt, traitlets
 ipython==7.13.0           # via -r requirements/run.txt
 isort==4.3.21             # via pylint, yala
@@ -53,6 +55,7 @@ prompt-toolkit==3.0.5     # via -r requirements/run.txt, ipython
 ptyprocess==0.6.0         # via -r requirements/run.txt, pexpect
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0        # via yala
+pydocstyle==5.1.1         # via -r requirements/dev.in
 pygments==2.6.1           # via -r requirements/run.txt, ipython, sphinx
 pyjwt==1.7.1              # via -r requirements/run.txt
 pylint==2.4.4             # via yala
@@ -65,7 +68,7 @@ pytz==2019.3              # via babel
 pyyaml==5.3.1             # via sphinx-autobuild
 requests==2.23.0          # via sphinx
 six==1.15.0               # via -r requirements/run.txt, astroid, flask-cors, livereload, packaging, pip-tools, python-engineio, python-socketio, tox, traitlets, virtualenv
-snowballstemmer==2.0.0    # via sphinx
+snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-autobuild==0.7.1   # via kytos-sphinx-theme
 sphinx==2.0.1             # via kytos-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -78,6 +81,7 @@ toml==0.10.0              # via tox
 tornado==6.0.4            # via livereload, sphinx-autobuild
 tox==3.14.6               # via -r requirements/dev.in
 traitlets==4.3.3          # via -r requirements/run.txt, ipython
+typed-ast==1.4.1          # via astroid
 urllib3==1.25.8           # via requests
 virtualenv==20.0.15       # via tox
 watchdog==0.10.2          # via -r requirements/run.txt, sphinx-autobuild
@@ -85,6 +89,7 @@ wcwidth==0.1.9            # via -r requirements/run.txt, prompt-toolkit, pytest
 werkzeug==1.0.1           # via -r requirements/run.txt, flask
 wrapt==1.11.2             # via astroid
 yala==2.2.0               # via -r requirements/dev.in
+zipp==3.3.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Fix issue #1178 

This PR adds pydocstyle to "dev.txt" and fix the linter error that was not traced before.
This is necessary because pydocstyle is one of the linters mentioned in "How to Contribute" guide. 

### :page_facing_up: Release Notes

Add pydocstyle to development requirements.
