### PR TITLE
Fix test_logs for Python 3.8

### DIFF
--- a/tests/unit/test_core/test_logs.py
+++ b/tests/unit/test_core/test_logs.py
@@ -1,5 +1,5 @@
 """Test the logs module."""
-import imp
+import importlib
 import logging
 from copy import copy
 from inspect import FrameInfo
@@ -189,7 +189,7 @@ class TestLogManager(LogTester):
         logging.root.addHandler(old_handler)
         old_handler.addFilter.assert_not_called()
         # Importing the module should add the filter to existent root handlers.
-        imp.reload(logs)
+        importlib.reload(logs)
         old_handler.addFilter.assert_called_once_with(
             logs.LogManager.filter_session_disconnected)
 

--- a/tests/unit/test_core/test_logs.py
+++ b/tests/unit/test_core/test_logs.py
@@ -61,6 +61,14 @@ class TestLogManager(LogTester):
         path.return_value.exists.return_value = False
         # Make sure we have the custome formatter section
         parser.__contains__.return_value = True
+
+        # Make 'parser' behave as a dict, this is necessary because the _PARSER
+        # is being patched returning a MagicMock (inside add_handler) and in
+        # 'logging' module (python 3.8) the 'Formatter' class includes a
+        # 'validate' method that breaks when receives a MagicMock object.
+        format_dict = {'formatter_console': {'format': None}}
+        parser.__getitem__.side_effect = format_dict.__getitem__
+
         handler = Mock()
 
         LogManager.add_handler(handler)


### PR DESCRIPTION
Fix part of #1149  

### :bookmark_tabs: Description of the Change

This PR fix one of the six errors listed in issue #1149 . 
The error is caused because a "MagicMock" object is passed to instantiate the "Formatter" class of "logging" module. As we can check in https://github.com/python/cpython/pull/9703 a validate method were added to "Formatter". The "validate" method breaks the test because expects a string or bytes-like object instead a MagicMock. To resolve it, the patched object behave as dict, allowing the validate method access a "None" value from one of your values.

Besides that the PR includes some commits did in parallel by @hdiogenes to ensure compatibility with python 3.7 and 3.8.

### :computer: Verification Process

Running tox locally.

### :page_facing_up: Release Notes

Once the other errors were fixed:
Adds support to python 3.7 and 3.8
