### PR TITLE
Update k-action-menu event documentation

### DIFF
--- a/docs/developer/events.rst
+++ b/docs/developer/events.rst
@@ -1,3 +1,7 @@
+Kytos have some events available, and to call them you should use the sintaxe
+`this.$kytos.$emit()` passing as parameters the specific events names and its
+objects of acceptance as documented bellow:
+
 **k-action-menu**
 
 ================= ====== =========================================== 
@@ -5,6 +9,41 @@ name              type   description
 ================= ====== =========================================== 
 addActionMenuItem object Add a new action item in the k-action-menu. 
 ================= ====== =========================================== 
+
+**Object Parameters:** The object should contain [name, author, shortkey, content]
+
+**Example**
+
+.. code-block:: html
+    
+    <template>
+        ...
+    </template>
+
+    <script>
+    /* All the javascript methods are optional */
+    module.exports = {
+        methods: {
+            actionMethod()  {
+                this.$kytos.$emit('statusMessage', 'Your Message Here')
+            }
+        },
+        data() {
+            return {
+                options: {
+                name: 'Status Bar Message Example', /* Name of the action */
+                author: 'Kytos', /* Name of the author */
+                shortkey: 'ctrl+alt+d', /* Shortkey to activate the action*/
+                action: this.actionMethod /* Method to call as action */
+                }
+            }
+        },
+        mounted() {
+            /* The event call */
+            this.$kytos.$emit('addActionMenuItem', this.options)
+        }
+    }
+    </script>
 
 **k-info-panel**
 

--- a/docs/developer/events.rst
+++ b/docs/developer/events.rst
@@ -1,6 +1,6 @@
-Kytos have some events available, and to call them you should use the sintaxe
+Kytos has some events available, and to call them you should use the syntax
 `this.$kytos.$emit()` passing as parameters the specific events names and its
-objects of acceptance as documented bellow:
+objects of acceptance as documented below:
 
 **k-action-menu**
 
@@ -61,4 +61,3 @@ name          type   description
 ============= ====== ================================== 
 statusMessage string Show a status message in StatusBar 
 ============= ====== ================================== 
-


### PR DESCRIPTION
Updated the documentation about k-action-menu event and added a example of usage with a `statusMessage` in the kytos UI