### PR TITLE
Added a configuration field to change token expiration time

### DIFF
--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -54,7 +54,7 @@ class Auth:
         """
         self.controller = controller
         self.namespace = "kytos.core.auth.users"
-        self.token_expiration_time = self.get_token_expiration()
+        self.token_expiration_minutes = self.get_token_expiration()
         if self.controller.options.create_superuser is True:
             self._create_superuser()
 
@@ -62,7 +62,7 @@ class Auth:
     def get_token_expiration():
         """Return token expiration time in minutes defined in kytos conf."""
         options = KytosConfig().options['daemon']
-        return options.token_expiration_time
+        return options.token_expiration_minutes
 
     @classmethod
     def get_jwt_secret(cls):
@@ -154,7 +154,7 @@ class Auth:
             if user.get("password") != hashlib.sha512(password).hexdigest():
                 raise KeyError
             time_exp = datetime.datetime.utcnow() + datetime.timedelta(
-                minutes=self.token_expiration_time
+                minutes=self.token_expiration_minutes
             )
             token = self._generate_token(username, time_exp)
             return {"token": token.decode()}, HTTPStatus.OK.value

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -16,7 +16,6 @@ from kytos.core.events import KytosEvent
 __all__ = ['authenticated']
 
 LOG = logging.getLogger(__name__)
-TOKEN_EXPIRATION_MINUTES = 180
 
 
 def authenticated(func):
@@ -55,8 +54,15 @@ class Auth:
         """
         self.controller = controller
         self.namespace = "kytos.core.auth.users"
+        self.token_expiration_time = self.get_token_expiration()
         if self.controller.options.create_superuser is True:
             self._create_superuser()
+
+    @staticmethod
+    def get_token_expiration():
+        """Return token expiration time in minutes defined in kytos conf."""
+        options = KytosConfig().options['daemon']
+        return options.token_expiration_time
 
     @classmethod
     def get_jwt_secret(cls):
@@ -148,7 +154,7 @@ class Auth:
             if user.get("password") != hashlib.sha512(password).hexdigest():
                 raise KeyError
             time_exp = datetime.datetime.utcnow() + datetime.timedelta(
-                minutes=TOKEN_EXPIRATION_MINUTES
+                minutes=self.token_expiration_time
             )
             token = self._generate_token(username, time_exp)
             return {"token": token.decode()}, HTTPStatus.OK.value

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -108,7 +108,7 @@ class KytosConfig():
                         'foreground': False,
                         'protocol_name': '',
                         'enable_entities_by_default': False,
-                        'token_expiration_time': 180,
+                        'token_expiration_minutes': 180,
                         'debug': False}
 
         """
@@ -130,7 +130,7 @@ class KytosConfig():
                     'napps_pre_installed': [],
                     'authenticate_urls': [],
                     'vlan_pool': {},
-                    'token_expiration_time': 180,
+                    'token_expiration_minutes': 180,
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()
@@ -171,8 +171,8 @@ class KytosConfig():
         options.port = int(options.port)
         options.api_port = int(options.api_port)
         options.protocol_name = str(options.protocol_name)
-        options.token_expiration_time = int(options.token_expiration_time)
-
+        options.token_expiration_minutes = int(options.
+                                               token_expiration_minutes)
         result = options.enable_entities_by_default in ['True', True]
         options.enable_entities_by_default = result
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -108,6 +108,7 @@ class KytosConfig():
                         'foreground': False,
                         'protocol_name': '',
                         'enable_entities_by_default': False,
+                        'token_expiration_time': 180,
                         'debug': False}
 
         """
@@ -129,6 +130,7 @@ class KytosConfig():
                     'napps_pre_installed': [],
                     'authenticate_urls': [],
                     'vlan_pool': {},
+                    'token_expiration_time': 180,
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()
@@ -169,6 +171,7 @@ class KytosConfig():
         options.port = int(options.port)
         options.api_port = int(options.api_port)
         options.protocol_name = str(options.protocol_name)
+        options.token_expiration_time = int(options.token_expiration_time)
 
         result = options.enable_entities_by_default in ['True', True]
         options.enable_entities_by_default = result

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -71,7 +71,7 @@ vlan_pool = {}
 jwt_secret = {{ jwt_secret }}
 
 # Time to expire authentication token in minutes
-token_expiration_time = 180
+token_expiration_minutes = 180
 
 # Define URLs that will require authentication
 #

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -70,6 +70,9 @@ vlan_pool = {}
 # The jwt_secret parameter is responsible for signing JSON Web Tokens.
 jwt_secret = {{ jwt_secret }}
 
+# Time to expire authentication token in minutes
+token_expiration_time = 180
+
 # Define URLs that will require authentication
 #
 # This must be a list of part of URLs. For example, if "kytos/mef_eline"


### PR DESCRIPTION
## :octocat: Are you working on some issue? Identify the issue!

Fix #1007 

### :bookmark_tabs: Description of the Change

Today, the authentication token expiration time is set in hard code in the authentication module. This commit solves this problem by moving this configuration to the `kytos.conf` file. 

### :computer: Verification Process

- Besides running unit tests, the token authentication expiration time was checked manually.

### :page_facing_up: Release Notes

- Added a configuration field to change token expiration time.
