### PR TITLE
Create a Blueprints section for the Dev Guide

### DIFF
--- a/docs/blueprints/EP000.rst
+++ b/docs/blueprints/EP000.rst
@@ -14,6 +14,9 @@
 :Status: Draft
 :Type: Standards Track
 
+*****************************
+EP000 - Enhancement Proposals
+*****************************
 
 ########
 Abstract

--- a/docs/blueprints/EP001.rst
+++ b/docs/blueprints/EP001.rst
@@ -9,6 +9,11 @@
 :Status: Accepted
 :Type: Informational
 
+
+**********************************************
+EP001 - Kytos testing pipeline and definitions
+**********************************************
+
 ########################
 Enhancement Proposal 001
 ########################

--- a/docs/blueprints/EP002.rst
+++ b/docs/blueprints/EP002.rst
@@ -2,6 +2,11 @@
 :Title: OpenFlow Handshake
 :Status: Accepted 
 
+
+**************************
+EP002 - OpenFlow Handshake
+**************************
+
 Abstract
 ########
 

--- a/docs/blueprints/EP003.rst
+++ b/docs/blueprints/EP003.rst
@@ -2,6 +2,11 @@
 :Title:  python-openflow Tests
 :Status: Accepted
 
+
+*****************************
+EP003 - python-openflow Tests
+*****************************
+
 Abstract
 ########
 

--- a/docs/blueprints/EP004.rst
+++ b/docs/blueprints/EP004.rst
@@ -2,6 +2,9 @@
 :Title: Updating specification
 :Status: Accepted
 
+******************************
+EP004 - Updating specification
+******************************
 
 Note: all the (draft) code is available at https://transfer.sh/ac8jc/version-inheritance.tar.gz.
 

--- a/docs/blueprints/EP005.rst
+++ b/docs/blueprints/EP005.rst
@@ -2,6 +2,10 @@
 :Title: Version inheritance problem
 :Status: Accepted
 
+***********************************
+EP005 - Version inheritance problem
+***********************************
+
 Description
 ###########
 

--- a/docs/blueprints/EP006.rst
+++ b/docs/blueprints/EP006.rst
@@ -2,6 +2,9 @@
 :Title: Version Inheritance
 :Status: Accepted
 
+***************************
+EP006 - Version Inheritance
+***************************
 
 Description
 ###########

--- a/docs/blueprints/EP007.rst
+++ b/docs/blueprints/EP007.rst
@@ -2,6 +2,11 @@
 :Title: OpenFlow handshake process on Kytos
 :Status: Draft 
 
+
+*******************************************
+EP007 - OpenFlow handshake process on Kytos
+*******************************************
+
 ########################
 Enhancement Proposal 007
 ########################

--- a/docs/blueprints/EP008.rst
+++ b/docs/blueprints/EP008.rst
@@ -2,6 +2,10 @@
 :Title: Pack/unpack tests and how to capture/dump binary message packets
 :Status: Draft 
 
+************************************************************************
+EP008 - Pack/unpack tests and how to capture/dump binary message packets
+************************************************************************
+
 ########################
 Enhancement Proposal 008
 ########################

--- a/docs/blueprints/EP009.rst
+++ b/docs/blueprints/EP009.rst
@@ -2,6 +2,10 @@
 :Title: Improve packing/unpacking message
 :Status: Draft 
 
+*****************************************
+EP009 - Improve packing/unpacking message
+*****************************************
+
 Objective
 #########
 Offer a more high\-level message packing/unpacking interface to the user

--- a/docs/blueprints/EP010.rst
+++ b/docs/blueprints/EP010.rst
@@ -2,6 +2,10 @@
 :Title: Implement OpenFlow protocol parsing headers
 :Status: Draft 
 
+***************************************************
+EP010 - Implement OpenFlow protocol parsing headers
+***************************************************
+
 Objective
 #########
 Implement the OpenFlow protocol by parsing the ``OFX.X--openflow.h`` headers

--- a/docs/blueprints/EP011.rst
+++ b/docs/blueprints/EP011.rst
@@ -2,6 +2,10 @@
 :Title: Multipart Request Creation
 :Status: Proposed
 
+**********************************
+EP011 - Multipart Request Creation
+**********************************
+
 Abstract
 ########
 

--- a/docs/blueprints/EP012.rst
+++ b/docs/blueprints/EP012.rst
@@ -2,6 +2,10 @@
 :Title: MEF E-Line (or Point-to-Point Ethernet Virtual Circuit) Service Provisioning NApp
 :Status: Work-in-progress
 
+*****************************************************************************************
+EP012 - MEF E-Line (or Point-to-Point Ethernet Virtual Circuit) Service Provisioning NApp
+*****************************************************************************************
+
 Summary
 =======
 

--- a/docs/blueprints/EP013.rst
+++ b/docs/blueprints/EP013.rst
@@ -2,6 +2,9 @@
 :Title: Topology NApp Improvements
 :Status: Finished
 
+**********************************
+EP013 - Topology NApp Improvements
+**********************************
 
 Summary
 =======

--- a/docs/blueprints/EP014.rst
+++ b/docs/blueprints/EP014.rst
@@ -2,6 +2,10 @@
 :Title: Pathfinder NApp Improvements
 :Status: Finished
 
+************************************
+EP014 - Pathfinder NApp Improvements
+************************************
+
 Summary
 =======
 

--- a/docs/blueprints/EP015.rst
+++ b/docs/blueprints/EP015.rst
@@ -2,6 +2,10 @@
 :Title: System tests for NApps validation.
 :Status: Working-in-progress
 
+******************************************
+EP015 - System tests for NApps validation.
+******************************************
+
 Summary
 =======
 

--- a/docs/blueprints/EP016.rst
+++ b/docs/blueprints/EP016.rst
@@ -9,6 +9,10 @@
 :Tags: eline, mef, circuit, provisioning, sdn, resilience
 
 
+***************************************
+EP016 - Kytos E-Line Link Up Definition
+***************************************
+
 Description
 ===========
 This blueprint describes what should be the concept of ``link up`` or link

--- a/docs/blueprints/EP017.rst
+++ b/docs/blueprints/EP017.rst
@@ -2,6 +2,10 @@
 :Title: Improvement of `kytos/flow_manager` logic.
 :Status: Draft
 
+**************************************************
+EP017 - Improvement of `kytos/flow_manager` logic.
+**************************************************
+
 Summary
 =======
 

--- a/docs/blueprints/EP018.rst
+++ b/docs/blueprints/EP018.rst
@@ -6,6 +6,10 @@
 :Status: Draft
 :Type: Standards Track
 
+********************************************
+EP018 - Kytos API Authentication definition.
+********************************************
+
 Abstract
 ========
 

--- a/docs/blueprints/EP019.rst
+++ b/docs/blueprints/EP019.rst
@@ -9,6 +9,9 @@
 :Status: Draft
 :Type: Standards Track
 
+******************************************************
+EP019 - Improvements on Statistics Metrics Collections
+******************************************************
 
 ########
 Abstract

--- a/docs/blueprints/EP020.rst
+++ b/docs/blueprints/EP020.rst
@@ -6,6 +6,9 @@
 :Status: Draft
 :Type: Standards Track
 
+*************************************
+EP020 - Settings and Data Persistence
+*************************************
 
 Abstract
 ========

--- a/docs/blueprints/EP021.rst
+++ b/docs/blueprints/EP021.rst
@@ -12,6 +12,10 @@
 :Type: Informational
 
 
+**********************************************
+EP021 - Kytos testing pipeline and definitions
+**********************************************
+
 Abstract
 ========
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -96,3 +96,4 @@ Kytos Summit provides an opportunity for developers, contributors and other inte
    unit_tests
    pyof
    rest_endpoints
+   ../blueprints/index.rst


### PR DESCRIPTION
Besides creating Blueprints section for the Dev Guide for #1180 , the titles in each Blueprint had to be updated to be displayed like this:

![Screenshot_2020-10-29 Blueprints — Kytos SDN Platform 2020 2b1 documentation(1)](https://user-images.githubusercontent.com/17555995/97634999-6836f680-1a15-11eb-8eea-e37cfaf1f25c.png)
