### PR TITLE
Remove call to `load_napp` when enabling a NApp

### DIFF
--- a/kytos/core/napps/manager.py
+++ b/kytos/core/napps/manager.py
@@ -125,8 +125,6 @@ class NAppsManager:
             try:
                 # Create symlink
                 enabled.symlink_to(installed)
-                if self._controller is not None:
-                    self._controller.load_napp(username, napp_name)
                 LOG.info("NApp enabled: %s", napp_id)
             except FileExistsError:
                 pass  # OK, NApp was already enabled


### PR DESCRIPTION
# Pull Request Template

### :octocat: Are you working on some issue? Identify the issue!

This will fix #1201: Name collision in Flask Blueprints creation.

**Work in progress**

### :bookmark_tabs: Description of the Change

Today, the `on_created` method tries to load a NApp that was already
loaded resulting in a name collision in Flask Blueprints creation.
This commit removes the `load_napp` in enable method (`napps/manager.py`).
Thus, the task of loading a NApp is performed only by the `on_created` method.

### :computer: Verification Process

Install `kytos 2020.2b2` and install a NApp with "kytos napps install" command.

### :page_facing_up: Release Notes

- Fix name collision in Flask Blueprints creation

