### PR TITLE
Update k-info-panel events doc

### DIFF
--- a/docs/developer/events.rst
+++ b/docs/developer/events.rst
@@ -15,6 +15,40 @@ showInfoPanel Object Show the info panel in the right.
 hideInfoPanel NULL   Hide the info panel displayed in the right. 
 ============= ====== =========================================== 
 
+The `k-info-panel` can be triggered by a `k-button` or a `k-action-menu` or
+anything that calls the method created to set-up a new `k-info-panel`.
+
+**Example**
+
+.. code-block:: html
+
+    <template>
+        ...
+    </template>
+
+    <script>
+    /* All the javascript methods are optional */
+    module.exports = {
+        methods: {
+            showInfoPanel()  {
+                var content = {
+                    "component": 'search-hosts',
+                    "content": {}, /* Content used in the component */
+                    "icon": "search",
+                    "title": "Search Hosts",
+                    "subtitle": "by kytos/UI Test"
+                }
+                this.$kytos.$emit("showInfoPanel", content)
+                // this.$kytos.$emit("hideInfoPanel")
+            }
+        },
+        data() {
+            return {
+            }
+        }
+    }
+    </script>
+
 **k-status-bar**
 
 ============= ====== ================================== 

--- a/docs/developer/events.rst
+++ b/docs/developer/events.rst
@@ -34,7 +34,7 @@ set up a new `k-info-panel`.
             showInfoPanel()  {
                 var content = {
                     "component": 'search-hosts',
-                    "content": {}, /* Content used in the component */
+                    "content": {msg:"content used in the component"},
                     "icon": "search",
                     "title": "Search Hosts",
                     "subtitle": "by kytos/UI Test"

--- a/docs/developer/events.rst
+++ b/docs/developer/events.rst
@@ -15,8 +15,9 @@ showInfoPanel Object Show the info panel in the right.
 hideInfoPanel NULL   Hide the info panel displayed in the right. 
 ============= ====== =========================================== 
 
-The `k-info-panel` can be triggered by a `k-button` or a `k-action-menu` or
-anything that calls the method created to set-up a new `k-info-panel`.
+The `k-info-panel` event can be triggered by a `k-button`, a
+`k-action-menu` or anything that calls the method created to
+set up a new `k-info-panel`.
 
 **Example**
 


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change

Added a example of how to use a k-info-panel event when working with Kytos UI
in a NApp, the example is a method named showInfoPanel() that can be called to
open the k-info-panel displaying some content but also showing the code that
close it.

### :page_facing_up: Release Notes

Update example of usage for the k-info-panel event in events.rst 