### PR TITLE
Updated the docs example of components events usage

### DIFF
--- a/docs/developer/events.rst
+++ b/docs/developer/events.rst
@@ -1,3 +1,7 @@
+Kytos has some events available, and to call them you should use the syntax
+`this.$kytos.$emit()` passing as parameters the specific events names and its
+objects of acceptance as documented below:
+
 **k-action-menu**
 
 ================= ====== =========================================== 
@@ -5,6 +9,41 @@ name              type   description
 ================= ====== =========================================== 
 addActionMenuItem object Add a new action item in the k-action-menu. 
 ================= ====== =========================================== 
+
+**Object Parameters:** The object should contain [name, author, shortkey, content]
+
+**Example**
+
+.. code-block:: html
+    
+    <template>
+        ...
+    </template>
+
+    <script>
+    /* All the javascript methods are optional */
+    module.exports = {
+        methods: {
+            actionMethod()  {
+                this.$kytos.$emit('statusMessage', 'Your Message Here')
+            }
+        },
+        data() {
+            return {
+                options: {
+                name: 'Status Bar Message Example', /* Name of the action */
+                author: 'Kytos', /* Name of the author */
+                shortkey: 'ctrl+alt+d', /* Shortkey to activate the action*/
+                action: this.actionMethod /* Method to call as action */
+                }
+            }
+        },
+        mounted() {
+            /* The event call */
+            this.$kytos.$emit('addActionMenuItem', this.options)
+        }
+    }
+    </script>
 
 **k-info-panel**
 
@@ -14,6 +53,41 @@ name          type   description
 showInfoPanel Object Show the info panel in the right.           
 hideInfoPanel NULL   Hide the info panel displayed in the right. 
 ============= ====== =========================================== 
+
+The `k-info-panel` event can be triggered by a `k-button`, a
+`k-action-menu` or anything that calls the method created to
+set up a new `k-info-panel`.
+
+**Example**
+
+.. code-block:: html
+
+    <template>
+        ...
+    </template>
+
+    <script>
+    /* All the javascript methods are optional */
+    module.exports = {
+        methods: {
+            showInfoPanel()  {
+                var content = {
+                    "component": 'search-hosts',
+                    "content": {msg:"content used in the component"},
+                    "icon": "search",
+                    "title": "Search Hosts",
+                    "subtitle": "by kytos/UI Test"
+                }
+                this.$kytos.$emit("showInfoPanel", content)
+                // this.$kytos.$emit("hideInfoPanel")
+            }
+        },
+        data() {
+            return {
+            }
+        }
+    }
+    </script>
 
 **k-status-bar**
 


### PR DESCRIPTION
The PRs https://github.com/kytos/kytos/pull/1207 and https://github.com/kytos/kytos/pull/1196 were conflicting because they make similar changes
 in the same file, so just one PR is good enough

### :bookmark_tabs: Description of the Change

Updated the documentation about k-action-menu event and added a example
of usage with a statusMessage in the kytos UI

Added a example of how to use a k-info-panel event when working with Kytos UI
in a NApp, the example is a method named showInfoPanel() that can be called to
open the k-info-panel displaying some content but also showing the code that
close it.


### :page_facing_up: Release Notes

- Update example of usage for the `k-info-panel` event in events.rst.
- Update example of usage for the `k-action-menu` event in events.rst.
