### PR TITLE
Update get_interface_by_port_no method to work with v0x01 and v0x04.

### DIFF
--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -139,6 +139,9 @@ class Switch(GenericEntity):
             :class:`~.core.switch.Interface`: Interface from specific port.
 
         """
+        # pyof v0x01 stores port_no in the value attribute
+        port_no = getattr(port_no, 'value', port_no)
+
         return self.interfaces.get(port_no)
 
     def get_flow_by_id(self, flow_id):


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!
Fix https://github.com/kytos/kytos/issues/1210



### :bookmark_tabs: Description of the Change

This PR update `get_interface_by_port_no` to return 'value' attribute if it is present.  

### :page_facing_up: Release Notes

N/A
