### PR TITLE
Fix Blueprints table order and some linter issues

### DIFF
--- a/docs/blueprints/make_blueprints_table.py
+++ b/docs/blueprints/make_blueprints_table.py
@@ -1,66 +1,80 @@
-import re
-import os
+"""Generate Blueprints table."""
 import glob
- 
-  
+import re
+
+
 def create_table(directory):
-    # Create the table header and cells
-    table_header = ''
-    table_cell = ''
-    
-    bps_rst = [] 
+    """Create the table header and cells."""
+    t_header = ''
+    t_cell = ''
+
+    bps_rst = []
     bps_titles = []
     bps_status = []
-    
+
     max_len_title = -1
     max_len_status = -1
     max_len_bps = -1
-    
-    for fp in glob.glob(f'{directory}/EP*.rst'):
-        split_dir = ''.join(fp.split('./blueprints/'))
+
+    for fp_file in sorted(glob.glob(f'{directory}/EP*.rst')):
+        split_dir = ''.join(fp_file.split('./blueprints/'))
         bp_rst = ''.join(split_dir.split('.rst'))
         bps_rst.append(f" :doc:`{bp_rst}<{bp_rst}/>` ")
-        if max_len_bps < len(bps_rst[-1]): max_len_bps = len(bps_rst[-1])
-        
-        with open(fp) as origin_file:
+        if max_len_bps < len(bps_rst[-1]):
+            max_len_bps = len(bps_rst[-1])
+
+        with open(fp_file) as origin_file:
             title = ''
             status = ''
             for line in origin_file:
                 if re.findall(r':Title:', line):
                     title = ''.join(line.split(':Title:'))
                     bps_titles.append(''.join(title.split("\n")))
-                    if max_len_title < len(title): max_len_title = len(title)
-                    
+                    if max_len_title < len(title):
+                        max_len_title = len(title)
+
                 if re.findall(r':Status:', line):
                     status = ''.join(line.split(':Status:'))
                     bps_status.append(''.join(status.split("\n")))
-                    if max_len_status < len(status): max_len_status = len(status)
+                    if max_len_status < len(status):
+                        max_len_status = len(status)
                     break
-    
-    th_title_len = (max_len_title - len(' Title'))
-    th_status_len = (max_len_status - len(' Status'))
-    th_bps_len = (max_len_bps - len(' Blueprint'))
-    
-    table_header += f"+{'-' * max_len_bps}+{'-' * max_len_title}+{'-' * max_len_status}+\n"
-    table_header += f"|{' Blueprint'}{' ' * th_bps_len}|{' Title'}{' ' * th_title_len}|{' Status'}{' ' * th_status_len}|\n"
-    table_header += f"+{'=' * max_len_bps}+{'=' * max_len_title}+{'=' * max_len_status}+\n"
-           
-    for i in range(len(bps_rst)):
+
+    th_title_len = max_len_title - len(' Title')
+    th_status_len = max_len_status - len(' Status')
+    th_bps_len = max_len_bps - len(' Blueprint')
+
+    t_header += f"+{'-' * max_len_bps}+"
+    t_header += f"{'-' * max_len_title}+{'-' * max_len_status}+\n"
+    t_header += f"|{' Blueprint'}{' ' * th_bps_len}|{' Title'}"
+    t_header += f"{' ' * th_title_len}|{' Status'}{' ' * th_status_len}|\n"
+    t_header += f"+{'=' * max_len_bps}+{'=' * max_len_title}+"
+    t_header += f"{'=' * max_len_status}+\n"
+
+    for i, _ in enumerate(bps_rst, start=0):
         title_space = max_len_title - len(bps_titles[i])
         status_space = max_len_status - len(bps_status[i])
-        bps_space = max_len_bps - len(bps_rst[i])
-        
-        table_cell += f"|{bps_rst[i]}{' ' * bps_space}|{bps_titles[i]}{' ' * title_space}|{bps_status[i]}{' ' * status_space}|\n"
-        table_cell += f"+{'-' * max_len_bps}+{'-' * max_len_title}+{'-' * max_len_status}+\n"
-        
-    return table_header + table_cell
+        bp_space = max_len_bps - len(bps_rst[i])
+
+        name = bps_rst[i]
+        title = bps_titles[i]
+        status = bps_status[i]
+
+        t_cell += f"|{name}{' ' * bp_space}|{title}{' ' * title_space}|"
+        t_cell += f"{status}{' ' * status_space}|\n"
+        t_cell += f"+{'-' * max_len_bps}+{'-' * max_len_title}+"
+        t_cell += f"{'-' * max_len_status}+\n"
+
+    return t_header + t_cell
 
 
 def write_new_index_rst(directory):
+    """Write table of blueprints in index.rst."""
     blueprints_table = create_table(directory)
-    
-    with open(f'{directory}/bp_table.rst', 'w') as fp:
-        fp.write(blueprints_table)
+
+    with open(f'{directory}/bp_table.rst', 'w') as fp_file:
+        fp_file.write(blueprints_table)
+
 
 if __name__ == '__main__':
-    write_new_index_rst('./blueprints')    
+    write_new_index_rst('./blueprints')


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change

Blueprints `EP*.rst` files were coming unordered from the file system, so the fix just needed a sorted function in the entry.

**Before**
![Screenshot_2020-11-20 Blueprints — Kytos SDN Platform 2020 2b2 documentation](https://user-images.githubusercontent.com/10928556/99863735-4a753100-2b7e-11eb-9b2b-6cffeab1dc20.png)

**Now**

![2020-11-20 22 16 17 0 0 0 0 74e845ae59f0](https://user-images.githubusercontent.com/10928556/99863755-637de200-2b7e-11eb-9ec7-2d78849aee59.png)



### :page_facing_up: Release Notes

-  Fix Blueprints table order and some linter issues.