### PR TITLE
Add a table of Kytos standards colors

### DIFF
--- a/docs/developer/kytos_colors.rst
+++ b/docs/developer/kytos_colors.rst
@@ -1,0 +1,21 @@
+.. role:: hexa
+.. role:: kytos-white
+.. role:: kytos-dark-white
+
+.. role:: kytos-black
+
+.. role:: kytos-gray
+.. role:: kytos-light-gray
+.. role:: kytos-medium-gray
+.. role:: kytos-dark-gray
+.. role:: kytos-extra-dark
+
+.. role:: kytos-purple
+.. role:: kytos-dark-purple
+
+.. role:: kytos-blue
+.. role:: kytos-dark-blue
+
+.. role:: kytos-green
+.. role:: kytos-yellow
+.. role:: kytos-red

--- a/docs/developer/web-ui.rst
+++ b/docs/developer/web-ui.rst
@@ -312,3 +312,31 @@ Below is an example of usage the `Textarea`_ component:
         ...
       </div>
     </template>
+
+Kytos Colors
+************
+We also have some standard colors that we strongly recommend to be used in your
+NApp's color scheme if needed.
+
+.. include:: ./kytos_colors.rst
+
+====================================== ===============
+Color                                  Hexadecimal    
+====================================== ===============
+:kytos-white:`kytos-white`             :hexa:`#EEE`
+:kytos-dark-white:`kytos-dark-white`   :hexa:`#CCC`
+:kytos-black:`kytos-black`             :hexa:`#222`
+:kytos-gray:`kytos-gray`               :hexa:`#515151`
+:kytos-light-gray:`kytos-light-gray`   :hexa:`#b3b3b3`
+:kytos-medium-gray:`kytos-medium-gray` :hexa:`#414141`
+:kytos-dark-gray:`kytos-dark-gray`     :hexa:`#313131`
+:kytos-extra-dark:`kytos-extra-dark`   :hexa:`#2a2a2a`
+:kytos-purple:`kytos-purple`           :hexa:`#554077`
+:kytos-dark-purple:`kytos-dark-purple` :hexa:`#322c5d`
+:kytos-blue:`kytos-blue`               :hexa:`#008690`
+:kytos-dark-blue:`kytos-dark-blue`     :hexa:`#008690`
+:kytos-green:`kytos-green`             :hexa:`#8bc34a`
+:kytos-yellow:`kytos-yellow`           :hexa:`#f9a825`
+:kytos-red:`kytos-red`                 :hexa:`#dd2c00`
+====================================== ===============
+


### PR DESCRIPTION


### :bookmark_tabs: Description of the Change

We have standard colors to use in our UI and we never get this available
for the user, so a table of those standard colors was added to web-ui.rst 
like this:

![Screenshot_2020-12-08 Web Interface — Kytos SDN Platform 2020 2b3 documentation](https://user-images.githubusercontent.com/17555995/101541125-b8dc3080-397f-11eb-89a6-92473f50696b.png)



### :page_facing_up: Release Notes

- [docs] Added table of Kytos standard colors
