### PR TITLE
Fix Runtime errors when closing Kytos 

### DIFF
--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -414,7 +414,9 @@ class Controller:
 
         try:
             # Python >= 3.9
+            # pylint: disable=unexpected-keyword-arg
             self._pool.shutdown(wait=graceful, cancel_futures=True)
+            # pylint: enable=unexpected-keyword-arg
         except TypeError:
             self._pool.shutdown(wait=graceful)
 

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -167,12 +167,13 @@ def async_main(config):
         controller.log.error(exc)
         controller.log.info("Shutting down Kytos...")
     finally:
-        pending = [t for t in asyncio_all_tasks() if
-                   t is not asyncio_current_task()]
+        if loop.is_running():
+            pending = [t for t in asyncio_all_tasks() if
+                    t is not asyncio_current_task()]
 
-        for task in pending:
-            task.cancel()
-            # Now we should await task to execute its cancellation.
-            # A cancelled task raises asyncio.CancelledError that we suppress.
-            with suppress(asyncio.CancelledError):
-                loop.run_until_complete(task)
+            for task in pending:
+                task.cancel()
+                # Now we should await task to execute its cancellation.
+                # A cancelled task raises asyncio.CancelledError that we suppress.
+                with suppress(asyncio.CancelledError):
+                    loop.run_until_complete(task)

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -158,6 +158,7 @@ def async_main(config):
         asyncio_all_tasks = asyncio.all_tasks
         asyncio_current_task = asyncio.current_task
     except AttributeError:
+        # pylint: disable=no-member
         asyncio_all_tasks = asyncio.Task.all_tasks
         asyncio_current_task = asyncio.Task.current_task
 
@@ -169,11 +170,12 @@ def async_main(config):
     finally:
         if loop.is_running():
             pending = [t for t in asyncio_all_tasks() if
-                    t is not asyncio_current_task()]
+                       t is not asyncio_current_task()]
 
             for task in pending:
                 task.cancel()
                 # Now we should await task to execute its cancellation.
-                # A cancelled task raises asyncio.CancelledError that we suppress.
+                # A cancelled task raises asyncio.CancelledError that
+                # we suppress.
                 with suppress(asyncio.CancelledError):
                     loop.run_until_complete(task)

--- a/tests/unit/test_core/test_kytosd.py
+++ b/tests/unit/test_core/test_kytosd.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kytos.core.kytosd import _create_pid_dir, async_main, main, start_shell
+from kytos.core.kytosd import _create_pid_dir, async_main, main, create_shell
 
 
 class TestKytosd(TestCase):
@@ -26,14 +26,15 @@ class TestKytosd(TestCase):
         (mock_mkdirs, mock_chmod) = args
         _create_pid_dir()
 
-        mock_mkdirs.assert_called_with('/var/run/kytos', exist_ok=True)
+        mock_mkdirs.assert_called_with('/var/run/kytos', exist_ok=Tre)
         mock_chmod.assert_called_with('/var/run/kytos', 0o1777)
 
     @staticmethod
     @patch('kytos.core.kytosd.InteractiveShellEmbed')
     def test_start_shell(mock_interactive_shell):
         """Test stop_api_server method."""
-        start_shell(MagicMock())
+        ipshell = create_shell(MagicMock())
+        ipshell()
 
         mock_interactive_shell.assert_called()
 

--- a/tests/unit/test_core/test_kytosd.py
+++ b/tests/unit/test_core/test_kytosd.py
@@ -26,7 +26,7 @@ class TestKytosd(TestCase):
         (mock_mkdirs, mock_chmod) = args
         _create_pid_dir()
 
-        mock_mkdirs.assert_called_with('/var/run/kytos', exist_ok=Tre)
+        mock_mkdirs.assert_called_with('/var/run/kytos', exist_ok=True)
         mock_chmod.assert_called_with('/var/run/kytos', 0o1777)
 
     @staticmethod

--- a/tests/unit/test_core/test_kytosd.py
+++ b/tests/unit/test_core/test_kytosd.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kytos.core.kytosd import _create_pid_dir, async_main, main, create_shell
+from kytos.core.kytosd import _create_pid_dir, async_main, create_shell, main
 
 
 class TestKytosd(TestCase):


### PR DESCRIPTION
Fix issue #1235 

### :bookmark_tabs: Description of the Change

Fixed kytosd shutdown to cancel tasks before closing the event loop that executes the tasks.
Closing the event loop while tasks are being completed causes Future Runtime errors.

### :computer: Verification Process

Verified using the command `pkill kytosd` with kytos in daemon and foreground modes.
