### PR TITLE
Fix PID value chosen for TestController::test_create_pidfile 

### DIFF
--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -183,7 +183,7 @@ class TestController(TestCase):
         (_, mock_getpid) = args
         mock_getpid.return_value = 2
         with tempfile.NamedTemporaryFile() as tmp_file:
-            tmp_file.write(b'4194305') # pid_max +1
+            tmp_file.write(b'4194305')  # pid_max +1
             tmp_file.seek(0)
             self.controller.options.pidfile = tmp_file.name
 

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -183,7 +183,7 @@ class TestController(TestCase):
         (_, mock_getpid) = args
         mock_getpid.return_value = 2
         with tempfile.NamedTemporaryFile() as tmp_file:
-            tmp_file.write(b'1')
+            tmp_file.write(b'4194305') # pid_max +1
             tmp_file.seek(0)
             self.controller.options.pidfile = tmp_file.name
 


### PR DESCRIPTION
Fix #1234 

### :bookmark_tabs: Description of the Change

This PR changes the value chosen for the PID in the TestController::test_create_pidfile unit test. The old value (1) refers to an existing process (init process on Linux systems). The new value refers to the maximum possible PID (for 32 and 64bits systems), plus 1.

### :computer: Verification Process

I've run the unit tests using tox and python setup.py coverage directly, both using a docker image python:3.6

### :page_facing_up: Release Notes

N/A